### PR TITLE
Support other types of value serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Key-Value Wide Column (KVWC) Database
 
-[![Build Status](https://github.com/dzlab/kvwc/actions/workflows/main.yml/badge.svg)](https://github.com/dzlab/kvwc/actions/workflows/main.yml)
+[![Build Status](https://github.com/dzlab/kvwc/actions/workflows/main.yml/badge.svg)](https://github.com/dzlab/kvwc/actions/workflows/ci.yml)
 [![PyPI version](https://img.shields.io/pypi/v/kvwc)](https://pypi.org/project/kvwc/)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/kvwc)](https://pypi.org/project/kvwc/)
 [![License](https://img.shields.io/github/license/dzlab/kvwc)](https://github.com/dzlab/kvwc/blob/main/LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: OS Independent",                           # If truly OS independent, otherwise specify
 ]
-dependencies = ["rocksdict"]
+dependencies = [
+    "msgpack-python>=0.5.6",
+    "rocksdict",
+]
 
 [project.urls]
 Homepage = "https://github.com/dzlab/kvwc"

--- a/src/key_codec.py
+++ b/src/key_codec.py
@@ -1,11 +1,6 @@
 import struct
 import logging
 
-# Define a separator that's unlikely to appear in keys/column names
-KEY_SEPARATOR = b'\x00'
-# Assuming timestamps are uint64 (e.g., nanoseconds or milliseconds)
-MAX_UINT64 = 2**64 - 1
-
 class KeyCodec:
     """
     A class for encoding and decoding keys used in the WideColumnDB.

--- a/src/serializer.py
+++ b/src/serializer.py
@@ -1,0 +1,143 @@
+import pickle
+import json
+import msgpack
+import logging
+
+logger = logging.getLogger(__name__)
+
+class Serializer:
+    """
+    Base class for value serialization.
+    """
+    def serialize(self, value):
+        """
+        Serializes a Python object into bytes.
+        Must be implemented by subclasses.
+        """
+        raise NotImplementedError("Subclasses must implement serialize method")
+
+    def deserialize(self, value_bytes):
+        """
+        Deserializes bytes back into a Python object.
+        Must be implemented by subclasses.
+        """
+        raise NotImplementedError("Subclasses must implement deserialize method")
+
+class StrSerializer(Serializer):
+    """
+    Serializer for simple string values, encoded as UTF-8 bytes.
+    """
+    def serialize(self, value):
+        """
+        Serializes a string value into UTF-8 bytes.
+        """
+        if value is None:
+            return None
+        try:
+            return str(value).encode('utf-8')
+        except Exception as e:
+            logger.error(f"Error serializing value '{value}' to string/utf-8: {e}")
+            raise
+
+    def deserialize(self, value_bytes):
+        """
+        Deserializes UTF-8 bytes back into a string.
+        """
+        if value_bytes is None:
+            return None
+        try:
+            return value_bytes.decode('utf-8')
+        except Exception as e:
+            logger.error(f"Error deserializing bytes '{value_bytes.hex()}' to string/utf-8: {e}")
+            raise
+
+class PickleSerializer(Serializer):
+    """
+    Serializer using Python's pickle module. Can handle most Python objects.
+    Note: Deserializing untrusted pickle data is insecure.
+    """
+    def serialize(self, value):
+        """
+        Serializes a Python object using pickle.
+        """
+        if value is None:
+            return None
+        try:
+            return pickle.dumps(value)
+        except Exception as e:
+            logger.error(f"Error serializing value '{value}' using pickle: {e}")
+            raise
+
+    def deserialize(self, value_bytes):
+        """
+        Deserializes bytes using pickle.
+        """
+        if value_bytes is None:
+            return None
+        try:
+            return pickle.loads(value_bytes)
+        except Exception as e:
+            # Log a more general error for pickle as data might be from an old format or untrusted
+            logger.error(f"Error deserializing bytes using pickle: {e}")
+            raise
+
+class JsonSerializer(Serializer):
+    """
+    Serializer using JSON. Only supports JSON-serializable types.
+    """
+    def serialize(self, value):
+        """
+        Serializes a Python object using JSON (to UTF-8 bytes).
+        """
+        if value is None:
+            return None
+        try:
+            # Use json.dumps and then encode the resulting string
+            return json.dumps(value).encode('utf-8')
+        except Exception as e:
+            logger.error(f"Error serializing value '{value}' using json: {e}")
+            raise
+
+    def deserialize(self, value_bytes):
+        """
+        Deserializes UTF-8 bytes using JSON.
+        """
+        if value_bytes is None:
+            return None
+        try:
+            # Decode bytes first, then parse JSON string
+            json_string = value_bytes.decode('utf-8')
+            return json.loads(json_string)
+        except Exception as e:
+            logger.error(f"Error deserializing bytes '{value_bytes.hex()}' using json: {e}")
+            raise
+
+class MsgPackSerializer(Serializer):
+    """
+    Serializer using MessagePack. Efficient binary serialization.
+    """
+    def serialize(self, value):
+        """
+        Serializes a Python object using msgpack.
+        """
+        if value is None:
+            return None
+        try:
+            # use_bin_type=True is often useful for bytes objects
+            return msgpack.packb(value, use_bin_type=True)
+        except Exception as e:
+            logger.error(f"Error serializing value '{value}' using msgpack: {e}")
+            raise
+
+    def deserialize(self, value_bytes):
+        """
+        Deserializes bytes using msgpack.
+        """
+        if value_bytes is None:
+            return None
+        try:
+            # raw=False decodes binary strings (bytes) to Python strings (str)
+            return msgpack.unpackb(value_bytes, raw=False)
+        except Exception as e:
+            logger.error(f"Error deserializing bytes '{value_bytes.hex()}' using msgpack: {e}")
+            raise

--- a/src/wide_column_db.py
+++ b/src/wide_column_db.py
@@ -139,7 +139,7 @@ class WideColumnDB:
                 # Add the version if we haven't reached the version limit for this column
                 if len(results[current_col_name]) < num_versions:
                      if rdb_value_bytes is not None:
-                         results[current_col_name].append((current_ts_ms, rdb_value_bytes.decode('utf-8')))
+                         results[current_col_name].append((current_ts_ms, self.serializer.deserialize(rdb_value_bytes)))
                 # else: num_versions reached for this column, skip adding this version, but continue scanning
                 # the prefix in case there are other columns covered by this prefix (if it's a row prefix scan).
 

--- a/src/wide_column_db.py
+++ b/src/wide_column_db.py
@@ -2,13 +2,23 @@ import logging
 import rocksdict as rocksdb
 import time
 from .key_codec import KeyCodec
+from .serializer import Serializer, StrSerializer # Import Serializer classes
 
 # Set the logging level
 logger = logging.getLogger(__name__)
 
 
 class WideColumnDB:
-    def __init__(self, db_path, key_codec=None):
+    def __init__(self, db_path, key_codec=None, serializer=None):
+        """
+        Initializes the WideColumnDB.
+
+        Args:
+            db_path (str): The path to the RocksDB database.
+            key_codec (KeyCodec, optional): The key codec to use. Defaults to KeyCodec().
+            serializer (Serializer, optional): The value serializer to use.
+                                              Defaults to StrSerializer().
+        """
         opts = rocksdb.Options()
         opts.create_if_missing(True)
         # For more advanced usage, you might explore Column Families here
@@ -19,9 +29,20 @@ class WideColumnDB:
         else:
             self.key_codec = key_codec
 
+        if serializer is None:
+            self.serializer = StrSerializer() # Default to StrSerializer
+        elif not isinstance(serializer, Serializer):
+             logger.warning("Provided serializer is not an instance of Serializer. Defaulting to StrSerializer.")
+             self.serializer = StrSerializer()
+        else:
+            self.serializer = serializer
+        logger.info(f"Using serializer: {type(self.serializer).__name__}")
+
+
     def _current_timestamp_ms(self):
         return int(time.time() * 1000)
 
+    # Removed _serialize_value and _deserialize_value as they are now handled by the Serializer class
 
     # --- Public API Methods ---
 
@@ -38,9 +59,15 @@ class WideColumnDB:
             timestamp_ms = item[2] if len(item) > 2 and item[2] is not None else self._current_timestamp_ms()
 
             rdb_key = self.key_codec.encode(dataset_name=dataset_name, row_key=row_key, column_name=column_name, timestamp_ms=timestamp_ms)
-            rdb_value = str(value).encode('utf-8') # Assuming value can be stringified
-            batch.put(rdb_key, rdb_value)
-        self.db.write(batch)
+            rdb_value = self.serializer.serialize(value) # Use the serializer instance
+            # Assuming serializer returns bytes or None on failure (or raises exception)
+            if rdb_value is not None:
+                 batch.put(rdb_key, rdb_value)
+            else:
+                 logger.warning(f"Serialization failed for value of type {type(value).__name__} for row '{row_key}', column '{column_name}'. Skipping item.")
+
+        if batch.count() > 0: # Only write if batch is not empty
+             self.db.write(batch)
 
     def get_row(self, row_key, column_names=None, num_versions=1, dataset_name=None, start_ts_ms=None, end_ts_ms=None):
         """

--- a/tests/test_wide_column_db.py
+++ b/tests/test_wide_column_db.py
@@ -30,6 +30,7 @@ if PROJECT_ROOT_DIR not in sys.path:
     sys.path.insert(0, PROJECT_ROOT_DIR)
 
 from src import WideColumnDB
+from src.key_codec import KeyCodec
 
 TEST_DB_PATH_BASE = "test_db_temp_wide_column_main"
 
@@ -485,7 +486,7 @@ class TestWideColumnDB(unittest.TestCase):
 
         # A key that might be too short if split by KEY_SEPARATOR
         # Manually craft a key that would lead to insufficient parts
-        raw_key_too_short = b"rowkey" + KEY_SEPARATOR + b"colname"
+        raw_key_too_short = b"rowkey" + KeyCodec.KEY_SEPARATOR + b"colname"
         # This key is missing the timestamp part
         self.db.db.put(raw_key_too_short, b"value")
 
@@ -509,7 +510,7 @@ class TestWideColumnDB(unittest.TestCase):
         self.assertEqual(res["colname_valid"][0], (self.current_time, "v"))
 
         # Test with dataset name expected but key is too short
-        raw_key_dataset_too_short = b"dataset" + KEY_SEPARATOR + b"row" + KEY_SEPARATOR + b"col"
+        raw_key_dataset_too_short = b"dataset" + KeyCodec.KEY_SEPARATOR + b"row" + KeyCodec.KEY_SEPARATOR + b"col"
         self.db.db.put(raw_key_dataset_too_short, b"value_ds_short")
         self.db.put_row("row", [("col_valid_ds", "val_ds", self.current_time)], dataset_name="dataset")
 
@@ -520,7 +521,7 @@ class TestWideColumnDB(unittest.TestCase):
         # Test with key that has incorrect timestamp bytes (not 8 bytes)
         # struct.error in _decode_key
         invalid_ts_bytes = b"short"
-        key_bad_ts = b"row_bad_ts" + KEY_SEPARATOR + b"col_bad_ts" + KEY_SEPARATOR + invalid_ts_bytes
+        key_bad_ts = b"row_bad_ts" + KeyCodec.KEY_SEPARATOR + b"col_bad_ts" + KeyCodec.KEY_SEPARATOR + invalid_ts_bytes
         self.db.db.put(key_bad_ts, b"value_bad_ts")
         self.db.put_row("row_bad_ts", [("col_good_ts", "val_good_ts", self.current_time)])
 

--- a/tests/test_wide_column_db.py
+++ b/tests/test_wide_column_db.py
@@ -29,7 +29,7 @@ PROJECT_ROOT_DIR = os.path.dirname(KVWC_DIR) # This is /
 if PROJECT_ROOT_DIR not in sys.path:
     sys.path.insert(0, PROJECT_ROOT_DIR)
 
-from src import WideColumnDB, MAX_UINT64, KEY_SEPARATOR
+from src import WideColumnDB
 
 TEST_DB_PATH_BASE = "test_db_temp_wide_column_main"
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,11 +7,21 @@ name = "kvwc"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "msgpack-python" },
     { name = "rocksdict" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "rocksdict" }]
+requires-dist = [
+    { name = "msgpack-python", specifier = ">=0.5.6" },
+    { name = "rocksdict" },
+]
+
+[[package]]
+name = "msgpack-python"
+version = "0.5.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/20/6eca772d1a5830336f84aca1d8198e5a3f4715cd1c7fc36d3cc7f7185091/msgpack-python-0.5.6.tar.gz", hash = "sha256:378cc8a6d3545b532dfd149da715abae4fda2a3adb6d74e525d0d5e51f46909b", size = 138996, upload-time = "2018-03-10T09:22:56.493Z" }
 
 [[package]]
 name = "rocksdict"


### PR DESCRIPTION
Values are strictly stored and retrieved as UTF-8 encoded strings (`str(value).encode('utf-8')` and `rdb_value_bytes.decode('utf-8')`). This limits the types of data we can store. For storing arbitrary binary data, numbers, or structured data (like JSON or protocol buffers), we would need a more flexible serialization mechanism. Consider using a library like `pickle`, `json` (with careful encoding/decoding), `msgpack`, or protocol buffers to handle serialization and deserialization of values, potentially storing a type indicator alongside the value if different columns have different data types.