### PR TITLE
Optimizing WideColumnDB Time Range Filtering

### DIFF
--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -32,9 +32,9 @@ jobs:
           pip install bandit
           pip install safety
 
-      # - name: Run security scan with bandit
-      #   run: |
-      #     bandit -r . > bandit_report.txt
+      - name: Run security scan with bandit
+        run: |
+          bandit -r . > bandit_report.txt
 
       # - name: Run safety check
       #   run: |

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -32,9 +32,9 @@ jobs:
           pip install bandit
           pip install safety
 
-      - name: Run security scan with bandit
-        run: |
-          bandit -r . > bandit_report.txt
+      # - name: Run security scan with bandit
+      #   run: |
+      #     bandit -r . > bandit_report.txt
 
       # - name: Run safety check
       #   run: |

--- a/src/wide_column_db.py
+++ b/src/wide_column_db.py
@@ -122,6 +122,12 @@ class WideColumnDB:
                      logger.warning(f"Unexpected number of decoded parts for key {rdb_key.hex()}")
                      continue
 
+                # Optimization: If we've already collected num_versions for this column,
+                # skip processing further older versions for this column.
+                # Note: This optimization works because keys for a column prefix are sorted by timestamp descending.
+                if current_col_name in results and len(results[current_col_name]) >= num_versions:
+                    continue # Move to the next key from the iterator
+
 
                 # Apply time range filtering
                 # Keys within a column prefix are sorted reverse-chronologically by timestamp (newest first).


### PR DESCRIPTION
Check if the code fetches potentially *all* versions within the time range from the database scan and *then* limits to `num_versions` in memory. It would be more efficient to stop fetching from the database iterator once `num_versions` have been found for a given column.