### PR TITLE
Support passing options for RocksDB

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,3 +2,4 @@ from .wide_column_db import *
 from .key_codec import *
 from .length_prefixed_key_codec import *
 from .logging_config import *
+from .db_manager import *

--- a/src/db_manager.py
+++ b/src/db_manager.py
@@ -1,0 +1,111 @@
+import logging
+import rocksdict as rocksdb
+
+logger = logging.getLogger(__name__)
+
+class RocksDBManager:
+    """
+    Manages the lifecycle of a RocksDB database instance.
+    Handles opening, closing, and applying RocksDB options.
+    """
+    def __init__(self, db_path, rocksdb_options=None):
+        """
+        Initializes the RocksDBManager.
+
+        Args:
+            db_path (str): The path to the RocksDB database directory.
+            rocksdb_options (dict, optional): A dictionary of RocksDB options to apply.
+                                              Keys should correspond to settable options
+                                              (e.g., 'max_open_files'). Values are the
+                                              desired option values. Defaults to None.
+        """
+        self._db_path = db_path
+        self._rocksdb_options = rocksdb_options
+        self._db = None # Holds the RocksDB instance
+
+    def open_db(self):
+        """
+        Opens the RocksDB database instance.
+
+        Applies the specified options and creates the database if it doesn't exist.
+        Stores the opened database instance internally.
+
+        Returns:
+            rocksdict.Rdict: The opened RocksDB database instance.
+
+        Raises:
+            Exception: If there is an error opening the database.
+        """
+        if self._db is not None:
+            logger.warning(f"Database at {self._db_path} is already open.")
+            return self._db
+
+        opts = rocksdb.Options()
+        opts.create_if_missing(True) # Set default option
+
+        # Apply provided options
+        if self._rocksdb_options is not None:
+            if not isinstance(self._rocksdb_options, dict):
+                 logger.warning("Provided rocksdb_options is not a dictionary. Ignoring.")
+            else:
+                for key, value in self._rocksdb_options.items():
+                    # Attempt to find and call the corresponding setter method (common rocksdict pattern)
+                    setter_name = f"set_{key}"
+                    setter_method = getattr(opts, setter_name, None)
+
+                    if setter_method and callable(setter_method):
+                        try:
+                            setter_method(value)
+                            logger.debug(f"Applied RocksDB option: {key} = {value}")
+                        except Exception as e:
+                            logger.warning(f"Failed to apply RocksDB option '{key}' with value '{value}': {e}")
+                    # Also try setting attributes directly (less common for complex options)
+                    elif hasattr(opts, key):
+                         try:
+                             setattr(opts, key, value)
+                             logger.debug(f"Applied RocksDB attribute option: {key} = {value}")
+                         except Exception as e:
+                             logger.warning(f"Failed to apply RocksDB attribute option '{key}' with value '{value}': {e}")
+                    else:
+                        logger.warning(f"Unknown or unsettable RocksDB option ignored: {key}")
+
+        try:
+            self._db = rocksdb.Rdict(self._db_path, opts)
+            logger.info(f"Successfully opened RocksDB database at {self._db_path}")
+            return self._db
+        except Exception as e:
+            logger.error(f"Failed to open RocksDB database at {self._db_path}: {e}")
+            # Re-raise the exception to indicate failure
+            raise e
+
+    def close_db(self):
+        """
+        Closes the RocksDB database instance if it is open.
+        """
+        if self._db is not None:
+            logger.info(f"Closing RocksDB database at {self._db_path}")
+            # The rocksdict object does not have an explicit close method.
+            # Deleting the object triggers the underlying C++ cleanup.
+            del self._db
+            self._db = None
+        else:
+            logger.warning(f"Database at {self._db_path} is not open. Cannot close.")
+
+    @property
+    def db(self):
+        """
+        Provides access to the underlying RocksDB instance.
+        Returns None if the database is not open.
+        """
+        return self._db
+
+    def __enter__(self):
+        """Context management protocol entry: Opens the database."""
+        self.open_db()
+        return self.db
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context management protocol exit: Closes the database."""
+        self.close_db()
+        # Return False to propagate any exceptions, True to suppress
+        return False

--- a/tests/test_wide_column_db.py
+++ b/tests/test_wide_column_db.py
@@ -375,7 +375,7 @@ class TestWideColumnDB(unittest.TestCase):
         temp_db.put_row("r1", [("c1", "v1", self.current_time)])
 
         temp_db.close()
-        self.assertIsNone(temp_db.db) # Internal RocksDB instance should be None
+        self.assertIsNone(temp_db._db_manager.db) # Internal RocksDB instance should be None
 
         with self.assertRaises(RuntimeError):
             temp_db.put_row("r2", [("c2", "v2", self.current_time + 1)])
@@ -535,7 +535,7 @@ class TestWideColumnDB(unittest.TestCase):
         # Manually craft a key that would lead to insufficient parts
         raw_key_too_short = b"rowkey" + KeyCodec.KEY_SEPARATOR + b"colname"
         # This key is missing the timestamp part
-        self.db.db.put(raw_key_too_short, b"value")
+        self.db._db_manager.db.put(raw_key_too_short, b"value")
 
         # When get_row scans, it should ideally skip this malformed key.
         # We put a valid key nearby to ensure scan continues.
@@ -558,7 +558,7 @@ class TestWideColumnDB(unittest.TestCase):
 
         # Test with dataset name expected but key is too short
         raw_key_dataset_too_short = b"dataset" + KeyCodec.KEY_SEPARATOR + b"row" + KeyCodec.KEY_SEPARATOR + b"col"
-        self.db.db.put(raw_key_dataset_too_short, b"value_ds_short")
+        self.db._db_manager.db.put(raw_key_dataset_too_short, b"value_ds_short")
         self.db.put_row("row", [("col_valid_ds", "val_ds", self.current_time)], dataset_name="dataset")
 
         res_ds = self.db.get_row("row", ["col_valid_ds"], dataset_name="dataset")
@@ -569,7 +569,7 @@ class TestWideColumnDB(unittest.TestCase):
         # struct.error in _decode_key
         invalid_ts_bytes = b"short"
         key_bad_ts = b"row_bad_ts" + KeyCodec.KEY_SEPARATOR + b"col_bad_ts" + KeyCodec.KEY_SEPARATOR + invalid_ts_bytes
-        self.db.db.put(key_bad_ts, b"value_bad_ts")
+        self.db._db_manager.db.put(key_bad_ts, b"value_bad_ts")
         self.db.put_row("row_bad_ts", [("col_good_ts", "val_good_ts", self.current_time)])
 
         res_bad_ts = self.db.get_row("row_bad_ts", ["col_good_ts"])


### PR DESCRIPTION
Only `create_if_missing(True)` is set in the `rocksdb.Options`, but RocksDB has numerous options for tuning performance, memory usage, and disk space, such as cache sizes, write buffer sizes, compression algorithms, and compaction strategies. For a production system, exposing or carefully configuring these options based on the expected workload is essential.