### PR TITLE
RocksDB Column Families Implementation

### DIFF
--- a/src/db_manager.py
+++ b/src/db_manager.py
@@ -5,10 +5,10 @@ logger = logging.getLogger(__name__)
 
 class RocksDBManager:
     """
-    Manages the lifecycle of a RocksDB database instance.
+    Manages the lifecycle of a RocksDB database instance with support for Column Families.
     Handles opening, closing, and applying RocksDB options.
     """
-    def __init__(self, db_path, rocksdb_options=None):
+    def __init__(self, db_path, rocksdb_options=None, column_families=None):
         """
         Initializes the RocksDBManager.
 
@@ -18,30 +18,35 @@ class RocksDBManager:
                                               Keys should correspond to settable options
                                               (e.g., 'max_open_files'). Values are the
                                               desired option values. Defaults to None.
+            column_families (list, optional): A list of Column Family names (strings) to open/create.
+                                             Defaults to None, meaning only the 'default' CF is used.
         """
         self._db_path = db_path
         self._rocksdb_options = rocksdb_options
+        self._column_families = column_families if column_families is not None else [] # Store requested CFs
         self._db = None # Holds the RocksDB instance
 
     def open_db(self):
         """
-        Opens the RocksDB database instance.
+        Opens the RocksDB database instance with specified Column Families.
 
-        Applies the specified options and creates the database if it doesn't exist.
-        Stores the opened database instance internally.
+        Applies the specified options and creates the database and Column Families
+        if they don't exist. Stores the opened database instance internally.
 
         Returns:
-            rocksdict.Rdict: The opened RocksDB database instance.
+            rocksdict.Rdict: The opened RocksDB database instance, which can be
+                             indexed by CF name (including 'default').
 
         Raises:
-            Exception: If there is an error opening the database.
+            Exception: If there is an error opening the database or creating CFs.
         """
         if self._db is not None:
             logger.warning(f"Database at {self._db_path} is already open.")
             return self._db
 
         opts = rocksdb.Options()
-        opts.create_if_missing(True) # Set default option
+        opts.create_if_missing(True)
+        opts.create_missing_column_families(True) # Enable creating missing CFs
 
         # Apply provided options
         if self._rocksdb_options is not None:
@@ -69,9 +74,13 @@ class RocksDBManager:
                     else:
                         logger.warning(f"Unknown or unsettable RocksDB option ignored: {key}")
 
+        # Always include the 'default' CF when opening
+        all_cfs_to_open = list(set(['default'] + self._column_families))
+
         try:
-            self._db = rocksdb.Rdict(self._db_path, opts)
-            logger.info(f"Successfully opened RocksDB database at {self._db_path}")
+            # Open with multiple column families
+            self._db = rocksdb.Rdict(self._db_path, opts, column_families=all_cfs_to_open)
+            logger.info(f"Successfully opened RocksDB database at {self._db_path} with CFs: {all_cfs_to_open}")
             return self._db
         except Exception as e:
             logger.error(f"Failed to open RocksDB database at {self._db_path}: {e}")
@@ -86,6 +95,7 @@ class RocksDBManager:
             logger.info(f"Closing RocksDB database at {self._db_path}")
             # The rocksdict object does not have an explicit close method.
             # Deleting the object triggers the underlying C++ cleanup.
+            # If there are CF handles, they are also managed by the Rdict instance.
             del self._db
             self._db = None
         else:
@@ -96,9 +106,12 @@ class RocksDBManager:
         """
         Provides access to the underlying RocksDB instance.
         Returns None if the database is not open.
+        The returned object can be indexed by CF name to access specific CF handles.
+        e.g., db_instance['my_cf'].put(...)
         """
         return self._db
 
+    # Context management methods (__enter__ and __exit__) remain the same
     def __enter__(self):
         """Context management protocol entry: Opens the database."""
         self.open_db()

--- a/src/key_codec.py
+++ b/src/key_codec.py
@@ -3,11 +3,12 @@ import logging
 
 class KeyCodec:
     """
-    A class for encoding and decoding keys used in the WideColumnDB.
+    A class for encoding and decoding keys used in the WideColumnDB *within a Column Family*.
     Keys are structured to support efficient retrieval by row, column, and time range.
-    Key format (full key): [dataset_name]\x00[row_key]\x00[column_name]\x00[inverted_timestamp_ms]
-    Key format (prefix): [dataset_name]\x00[row_key]\x00[column_name]\x00
+    Key format (full key): [row_key]\x00[column_name]\x00[inverted_timestamp_ms]
+    Key format (prefix): [row_key]\x00[column_name]\x00
     Timestamp is inverted to ensure descending order (latest first).
+    Note: Dataset name is handled by Column Families, not part of the key here.
     """
 
     KEY_SEPARATOR = b'\x00'
@@ -15,23 +16,42 @@ class KeyCodec:
 
     def encode(self, dataset_name=None, row_key=None, column_name=None, timestamp_ms=None):
         """
-        Encodes components into a RocksDB key byte string or a prefix byte string.
+        Encodes components into a RocksDB key byte string or a prefix byte string
+        *without* the dataset_name, as that is handled by the Column Family.
         If timestamp_ms is provided, encodes a full key.
         If timestamp_ms is None, encodes a prefix.
         """
+        # Ignore dataset_name as it's handled by the Column Family
+        _ = dataset_name
+
         parts = []
 
-        if dataset_name is not None:
-            parts.append(str(dataset_name).encode('utf-8'))
-
+        # Row key is mandatory for valid keys/prefixes here
         if row_key is not None:
             parts.append(str(row_key).encode('utf-8'))
+        else:
+            # Invalid key state without a row key
+            logging.error("Cannot encode key or prefix without a row_key.")
+            return None
 
+
+        # Column name is mandatory for column-specific keys/prefixes
         if column_name is not None:
             parts.append(str(column_name).encode('utf-8'))
+        elif timestamp_ms is not None:
+             # Column name is required for a full key
+             logging.error("Cannot encode full key without a column_name.")
+             return None
+        # If column_name is None and timestamp_ms is None, this is a row prefix scan, which is okay.
+
 
         if timestamp_ms is not None:
             # This is a full key
+            if column_name is None:
+                 # Should have been caught above, but double check
+                 logging.error("Cannot encode full key without a column_name (timestamp provided but column_name is None).")
+                 return None
+
             # Invert timestamp for descending order (latest first)
             inverted_ts = KeyCodec.MAX_UINT64 - timestamp_ms
             timestamp_bytes = struct.pack('>Q', inverted_ts) # Big-endian 8-byte unsigned int
@@ -41,49 +61,43 @@ class KeyCodec:
             # This is a prefix for scanning/deletion
             # Append the separator to make it a valid prefix that matches keys
             # starting with these components followed by a separator.
+            # If only row_key is present, the prefix is row_key\x00
+            # If row_key and column_name are present, the prefix is row_key\x00column_name\x00
             return KeyCodec.KEY_SEPARATOR.join(parts) + KeyCodec.KEY_SEPARATOR
 
 
     def decode(self, rdb_key_bytes):
         """
-        Decodes a RocksDB key byte string back into its components.
+        Decodes a RocksDB key byte string back into its components *without*
+        expecting a dataset_name prefix.
         Assumes the key is a full key ending with a timestamp.
-        Returns (dataset_name, row_key, column_name, original_timestamp_ms) or None if malformed.
+        Returns (row_key, column_name, original_timestamp_ms) or None if malformed.
         """
         parts = rdb_key_bytes.split(KeyCodec.KEY_SEPARATOR)
 
-        dataset_name_bytes = None
         row_key_bytes = None
         column_name_bytes = None
         timestamp_bytes = None
 
         # Determine the structure based on the number of parts
-        if len(parts) == 4:
-            # Format: [dataset_name]\x00[row_key]\x00[column_name]\x00[timestamp]
-            dataset_name_bytes = parts[0]
-            row_key_bytes = parts[1]
-            column_name_bytes = parts[2]
-            timestamp_bytes = parts[3]
-        elif len(parts) == 3:
-            # Format: [row_key]\x00[column_name]\x00[timestamp]
-            # dataset_name remains None
+        # Expected format now: [row_key]\x00[column_name]\x00[timestamp] (3 parts)
+        if len(parts) == 3:
             row_key_bytes = parts[0]
             column_name_bytes = parts[1]
             timestamp_bytes = parts[2]
         else:
-            logging.warning(f"Malformed key during decode (unexpected parts count {len(parts)}): {rdb_key_bytes.hex()}")
+            logging.warning(f"Malformed key during decode (unexpected parts count {len(parts)}), expected 3: {rdb_key_bytes.hex()}")
             return None # Malformed key
 
         # Now decode the parts that are expected to be strings
-        dataset_name = None
         row_key = None
         column_name = None
 
         try:
-            if dataset_name_bytes is not None:
-                 dataset_name = dataset_name_bytes.decode('utf-8')
-            row_key = row_key_bytes.decode('utf-8')
-            column_name = column_name_bytes.decode('utf-8')
+            if row_key_bytes is not None:
+                row_key = row_key_bytes.decode('utf-8')
+            if column_name_bytes is not None:
+                 column_name = column_name_bytes.decode('utf-8')
         except UnicodeDecodeError:
              logging.warning(f"Malformed key during decode (unicode error): {rdb_key_bytes.hex()}")
              return None
@@ -96,7 +110,8 @@ class KeyCodec:
         try:
             inverted_ts = struct.unpack('>Q', timestamp_bytes)[0]
             original_timestamp_ms = KeyCodec.MAX_UINT64 - inverted_ts
-            return dataset_name, row_key, column_name, original_timestamp_ms
+            # Return tuple without dataset_name
+            return row_key, column_name, original_timestamp_ms
         except struct.error as e:
             logging.warning(f"Error unpacking timestamp: {e} for key {rdb_key_bytes.hex()}")
             return None

--- a/src/length_prefixed_key_codec.py
+++ b/src/length_prefixed_key_codec.py
@@ -6,13 +6,14 @@ MAX_UINT64 = 2**64 - 1
 
 class LengthPrefixedKeyCodec:
     """
-    A class for encoding and decoding keys used in the WideColumnDB
+    A class for encoding and decoding keys used in the WideColumnDB *within a Column Family*
     using a length-prefixed format.
     Keys are structured to support efficient retrieval by row, column, and time range.
-    Key format (full key): [len_dataset][dataset_name][len_row][row_key][len_column][column_name][inverted_timestamp_ms]
-    Key format (prefix): [len_dataset][dataset_name][len_row][row_key][len_column][column_name]
+    Key format (full key): [len_row][row_key][len_column][column_name][inverted_timestamp_ms]
+    Key format (prefix): [len_row][row_key][len_column][column_name] or [len_row][row_key]
     Timestamp is inverted to ensure descending order (latest first).
     Length prefix is a single byte (max length 255).
+    Note: Dataset name is handled by Column Families, not part of the key here.
     """
 
     MAX_UINT64 = 2**64 - 1
@@ -20,12 +21,15 @@ class LengthPrefixedKeyCodec:
     def encode(self, dataset_name=None, row_key=None, column_name=None, timestamp_ms=None):
         """
         Encodes components into a RocksDB key byte string or a prefix byte string
-        using the length-prefixed format.
+        using the length-prefixed format, *without* the dataset_name.
         If timestamp_ms is provided, encodes a full key.
         If timestamp_ms is None, encodes a prefix.
         String components are length-prefixed with a single byte (max length 255).
-        Returns bytes or None if a component is too long.
+        Returns bytes or None if a component is too long or mandatory parts are missing.
         """
+        # Ignore dataset_name as it's handled by the Column Family
+        _ = dataset_name
+
         encoded_parts = []
 
         def _encode_part(part):
@@ -42,19 +46,30 @@ class LengthPrefixedKeyCodec:
 
             return bytes([len(part_bytes)]) + part_bytes
 
-        # Encode string parts
-        encoded_dataset = _encode_part(dataset_name)
-        encoded_row = _encode_part(row_key)
-        encoded_column = _encode_part(column_name)
+        # Row key is mandatory
+        if row_key is not None:
+             encoded_row = _encode_part(row_key)
+             if encoded_row is None: return None # Failed to encode row key
+             encoded_parts.append(encoded_row)
+        else:
+            logging.error("Cannot encode key or prefix without a row_key.")
+            return None
 
-        # Check if any part encoding failed
-        if encoded_dataset is None or encoded_row is None or encoded_column is None:
-             return None
 
-        encoded_parts.extend([encoded_dataset, encoded_row, encoded_column])
+        # Column name is required for full keys or column prefixes
+        if timestamp_ms is not None or column_name is not None:
+             encoded_column = _encode_part(column_name)
+             if encoded_column is None: return None # Failed to encode column name
+             encoded_parts.append(encoded_column)
+
 
         if timestamp_ms is not None:
             # This is a full key
+            if column_name is None:
+                 # Should have been caught above, but double check
+                 logging.error("Cannot encode full key without a column_name (timestamp provided but column_name is None).")
+                 return None
+
             # Invert timestamp for descending order (latest first)
             inverted_ts = LengthPrefixedKeyCodec.MAX_UINT64 - timestamp_ms
             timestamp_bytes = struct.pack('>Q', inverted_ts) # Big-endian 8-byte unsigned int
@@ -62,14 +77,16 @@ class LengthPrefixedKeyCodec:
             return b''.join(encoded_parts)
         else:
             # This is a prefix for scanning/deletion
+            # The prefix is [len_row][row_key][len_column][column_name]
+            # or [len_row][row_key] if column_name was None.
             return b''.join(encoded_parts)
 
     def decode(self, rdb_key_bytes):
         """
         Decodes a RocksDB key byte string encoded with the length-prefixed format
-        back into its components.
+        back into its components, *without* expecting a dataset_name prefix.
         Assumes the key is a full key ending with a timestamp.
-        Returns (dataset_name, row_key, column_name, original_timestamp_ms) or None if malformed.
+        Returns (row_key, column_name, original_timestamp_ms) or None if malformed.
         """
         offset = 0
 
@@ -89,28 +106,29 @@ class LengthPrefixedKeyCodec:
             current_offset += length
 
             try:
+                # Decode to string if length > 0, otherwise return None or empty string?
+                # Let's return None for length 0, matching the encoding logic's handling of None.
                 part_str = part_bytes.decode('utf-8') if length > 0 else None
                 return part_str, current_offset
             except UnicodeDecodeError:
                  logging.warning(f"Malformed key during length-prefix decode (unicode error) decoding {length} bytes at offset {current_offset - length}: {data.hex()}")
                  return None, current_offset # Return offset to try and continue parsing
 
-        # Decode parts: dataset_name, row_key, column_name
-        dataset_name, offset = _decode_part(rdb_key_bytes, offset)
-        if dataset_name is None and offset < len(rdb_key_bytes) and rdb_key_bytes[offset-1] != 0:
-             # Failed to decode a non-empty part
-             logging.warning(f"Malformed key during length-prefix decode (failed to decode dataset_name): {rdb_key_bytes.hex()}")
-             return None
-
+        # Decode parts: row_key, column_name
         row_key, offset = _decode_part(rdb_key_bytes, offset)
-        if row_key is None and offset < len(rdb_key_bytes) and rdb_key_bytes[offset-1] != 0:
+        if row_key is None and (offset == 0 or (offset < len(rdb_key_bytes) and rdb_key_bytes[offset-1] != 0)):
+             # Failed to decode a non-empty row_key, or row_key was expected but not found
              logging.warning(f"Malformed key during length-prefix decode (failed to decode row_key): {rdb_key_bytes.hex()}")
              return None
 
         column_name, offset = _decode_part(rdb_key_bytes, offset)
-        if column_name is None and offset < len(rdb_key_bytes) and rdb_key_bytes[offset-1] != 0:
+        if column_name is None and (offset < len(rdb_key_bytes) and rdb_key_bytes[offset-1] != 0):
+             # Failed to decode a non-empty column_name, or column_name was expected but not found before timestamp
              logging.warning(f"Malformed key during length-prefix decode (failed to decode column_name): {rdb_key_bytes.hex()}")
-             return None
+             # Even if column_name is legitimately None (encoded as length 0),
+             # if there are subsequent bytes, it implies something is wrong unless
+             # those bytes are exactly the timestamp. So continue decoding timestamp.
+
 
         # Decode timestamp if remaining bytes match timestamp size
         timestamp_bytes_size = struct.calcsize('>Q')
@@ -120,15 +138,13 @@ class LengthPrefixedKeyCodec:
                 inverted_ts = struct.unpack('>Q', timestamp_bytes)[0]
                 original_timestamp_ms = LengthPrefixedKeyCodec.MAX_UINT64 - inverted_ts
                 # offset += timestamp_bytes_size # No need to update offset further
-                return dataset_name, row_key, column_name, original_timestamp_ms
+                # Return tuple without dataset_name
+                return row_key, column_name, original_timestamp_ms
             except struct.error as e:
                 logging.warning(f"Error unpacking timestamp during length-prefix decode: {e} for key {rdb_key_bytes.hex()}")
                 return None
-        elif len(rdb_key_bytes) - offset == 0:
-             # This might be a prefix, but decode is for full keys. Treat as malformed for now.
-             logging.warning(f"Malformed key during length-prefix decode (no timestamp found where expected): {rdb_key_bytes.hex()}")
-             return None
+        # Removed the check for len(rdb_key_bytes) - offset == 0 as decode is for full keys
         else:
-            # Remaining bytes are not the size of a timestamp
-            logging.warning(f"Malformed key during length-prefix decode (unexpected remaining bytes size {len(rdb_key_bytes) - offset}): {rdb_key_bytes.hex()}")
+            # Remaining bytes are not the size of a timestamp, or there was no column name
+            logging.warning(f"Malformed key during length-prefix decode (unexpected remaining bytes size {len(rdb_key_bytes) - offset} or missing column name): {rdb_key_bytes.hex()}")
             return None

--- a/src/wide_column_db.py
+++ b/src/wide_column_db.py
@@ -1,7 +1,7 @@
 import logging
 import rocksdict as rocksdb
 import time
-from .key_codec import KeyCodec
+from .key_codec import KeyCodec # Keep KeyCodec for now, will modify
 from .serializer import Serializer, StrSerializer # Import Serializer classes
 from .db_manager import RocksDBManager # Import the new DB manager
 
@@ -10,27 +10,36 @@ logger = logging.getLogger(__name__)
 
 
 class WideColumnDB:
-    def __init__(self, db_path, key_codec=None, serializer=None, rocksdb_options=None):
+    def __init__(self, db_path, key_codec=None, serializer=None, rocksdb_options=None, column_families=None):
         """
         Initializes the WideColumnDB.
 
         Args:
             db_path (str): The path to the RocksDB database.
             key_codec (KeyCodec, optional): The key codec to use. Defaults to KeyCodec().
+                                            Note: Codecs will now encode keys *without* dataset_name.
             serializer (Serializer, optional): The value serializer to use.
                                               Defaults to StrSerializer().
             rocksdb_options (dict, optional): A dictionary of RocksDB options to apply.
-                                              Keys should correspond to settable options
-                                              (e.g., 'max_open_files'). Values are the
-                                              desired option values. Defaults to None.
+                                              Keys should correspond to settable options. Defaults to None.
+            column_families (list, optional): A list of Column Family names (strings) to open/create.
+                                             These will correspond to dataset_names. Defaults to None.
+                                             The 'default' CF is always opened.
         """
-        # Initialize the DB manager
-        self._db_manager = RocksDBManager(db_path, rocksdb_options=rocksdb_options)
+        # Initialize the DB manager with provided column families
+        self._db_manager = RocksDBManager(db_path, rocksdb_options=rocksdb_options, column_families=column_families)
         # Open the database via the manager
         self._db_manager.open_db() # This will raise an exception if it fails
 
+        # Store the list of known column families for validation/reference
+        # The DB manager ensures 'default' is always included
+        self._known_column_families = ['default'] + (column_families if column_families is not None else [])
+        # Remove duplicates just in case 'default' was explicitly passed
+        self._known_column_families = list(set(self._known_column_families))
+
 
         if key_codec is None:
+            # Initialize default codec (will be modified later to exclude dataset_name)
             self.key_codec = KeyCodec()
         else:
             self.key_codec = key_codec
@@ -48,58 +57,93 @@ class WideColumnDB:
     def _current_timestamp_ms(self):
         return int(time.time() * 1000)
 
-    # Removed _serialize_value and _deserialize_value as they are now handled by the Serializer class
+    def _get_cf_handle(self, dataset_name):
+        """
+        Gets the rocksdict handle for the specified dataset_name (Column Family).
+        Uses 'default' CF if dataset_name is None or not provided.
+        Raises an error if the dataset_name corresponds to a CF that wasn't opened.
+        """
+        cf_name = dataset_name if dataset_name is not None else 'default'
+        if cf_name not in self._known_column_families:
+             # This check prevents using CFs that weren't specified during init.
+             # RocksDB might implicitly create them anyway depending on version/options,
+             # but requiring them to be listed in init makes the CFs explicit.
+             # Alternatively, we could allow implicit creation here, but being explicit
+             # is generally better for managing CFs.
+             logger.warning(f"Attempted to access unknown Column Family: {cf_name}. Was it included in column_families during initialization?")
+             # Decide whether to raise error or default to 'default'/'None' CF.
+             # For now, let's raise an error to enforce explicit CF listing.
+             raise ValueError(f"Column Family '{cf_name}' is not known. Please include it in the 'column_families' list when initializing WideColumnDB.")
+
+        db_instance = self._db_manager.db
+        if db_instance is None:
+            raise RuntimeError("Database is not initialized. Cannot get CF handle.")
+
+        # Access the CF handle using dictionary-like access
+        try:
+            return db_instance[cf_name]
+        except KeyError:
+             # This should ideally not happen if _known_column_families is correct and DB opened successfully
+             logger.error(f"Failed to get handle for Column Family '{cf_name}'. It might not have been opened correctly.")
+             raise
 
     # --- Public API Methods ---
 
     def put_row(self, row_key, items, dataset_name=None):
         """
-        Puts items into a row.
+        Puts items into a row within a specific dataset (Column Family).
         items: list of tuples, where each tuple is either:
                (column_name, value) - current server time is used as timestamp.
                (column_name, value, timestamp_ms) - the provided timestamp is used.
+        dataset_name: The name of the dataset (Column Family) to use. Defaults to 'default'.
         """
-        # Use the db instance from the manager
-        db_instance = self._db_manager.db
-        if db_instance is None:
-            raise RuntimeError("Database is not initialized. Cannot perform put_row operation.")
+        # Get the correct CF handle
+        cf_handle = self._get_cf_handle(dataset_name)
+
         batch, count  = rocksdb.WriteBatch(), 0
         for item in items:
             column_name, value = item[0], item[1]
             timestamp_ms = item[2] if len(item) > 2 and item[2] is not None else self._current_timestamp_ms()
 
-            rdb_key = self.key_codec.encode(dataset_name=dataset_name, row_key=row_key, column_name=column_name, timestamp_ms=timestamp_ms)
+            # Encode key *without* dataset_name
+            rdb_key = self.key_codec.encode(row_key=row_key, column_name=column_name, timestamp_ms=timestamp_ms)
+
+            # Check if key encoding failed (e.g., part too long for length prefix codec)
+            if rdb_key is None:
+                 logger.warning(f"Key encoding failed for row '{row_key}', column '{column_name}'. Skipping item.")
+                 continue
+
             rdb_value = self.serializer.serialize(value) # Use the serializer instance
             # Assuming serializer returns bytes or None on failure (or raises exception)
             if rdb_value is not None:
-                 batch.put(rdb_key, rdb_value)
+                 # Add to batch specifying the CF handle
+                 batch.put(rdb_key, rdb_value, column_family=cf_handle)
                  count += 1
             else:
                  logger.warning(f"Serialization failed for value of type {type(value).__name__} for row '{row_key}', column '{column_name}'. Skipping item.")
 
         if count > 0: # Only write if batch is not empty
             try:
-                 db_instance.write(batch)
+                 # Write batch to the database instance (the Rdict object itself)
+                 # The operations within the batch already specify the target CF
+                 self._db_manager.db.write(batch)
             except Exception as e:
-                 logger.error(f"Error writing batch to database for row '{row_key}': {e}")
+                 logger.error(f"Error writing batch to database for row '{row_key}' in CF '{dataset_name or 'default'}': {e}")
                  # Re-raise the exception to indicate failure
                  raise e
 
     def get_row(self, row_key, column_names=None, num_versions=1, dataset_name=None, start_ts_ms=None, end_ts_ms=None):
         """
-        Gets data for a row.
+        Gets data for a row within a specific dataset (Column Family).
         Returns a dictionary: {column_name: [(timestamp_ms, value), ...]}
+        dataset_name: The name of the dataset (Column Family) to use. Defaults to 'default'.
         """
-        # Use the db instance from the manager
-        db_instance = self._db_manager.db
-        if db_instance is None:
-            raise RuntimeError("Database is not initialized. Cannot perform get_row operation.")
+        # Get the correct CF handle
+        cf_handle = self._get_cf_handle(dataset_name)
+
         results = {}
 
-        # Build the prefix for scanning
-        # If specific column_names are given, we iterate and build prefixes for each.
-        # If not, we build a prefix for the entire row.
-
+        # Build the prefix for scanning *without* dataset_name
         target_columns = []
         if column_names:
             if isinstance(column_names, str): # Single column name
@@ -110,39 +154,55 @@ class WideColumnDB:
         scan_prefixes = []
         if target_columns:
             for col_name in target_columns:
-                # Prefix for a specific column: dataset? + row_key + col_name
-                scan_prefixes.append(self.key_codec.encode(dataset_name=dataset_name, row_key=row_key, column_name=col_name))
+                # Prefix for a specific column: row_key + col_name (no dataset)
+                scan_prefixes.append(self.key_codec.encode(row_key=row_key, column_name=col_name))
         else:
-            # Prefix for all columns in a row: dataset? + row_key
-            scan_prefixes.append(self.key_codec.encode(dataset_name=dataset_name, row_key=row_key))
+            # Prefix for all columns in a row: row_key (no dataset)
+            scan_prefixes.append(self.key_codec.encode(row_key=row_key))
 
-        logger.info(f'Prefixes to look for {scan_prefixes}')
 
-        # Use RocksDB iterator with seek for efficient scanning
+        # Filter out any potential None results from encoding (e.g., due to length prefix limits)
+        valid_scan_prefixes = [p for p in scan_prefixes if p is not None]
+
+        if not valid_scan_prefixes:
+            logger.warning(f"No valid scan prefixes could be generated for row '{row_key}' in CF '{dataset_name or 'default'}'. Returning empty results.")
+            return results
+
+        logger.info(f'Prefixes to look for in CF {dataset_name or "default"}: {valid_scan_prefixes}')
+
+        # Use RocksDB iterator on the specific CF handle
         # Iterate through each prefix and use from_key to seek
-        for prefix_bytes in scan_prefixes:
-            # Use items(from_key=prefix_bytes) to seek to the start of the prefix range
-            for rdb_key, rdb_value_bytes in db_instance.items(from_key=prefix_bytes):
+        for prefix_bytes in valid_scan_prefixes:
+            # Use items(from_key=prefix_bytes) on the CF handle to seek within that CF
+            for rdb_key, rdb_value_bytes in cf_handle.items(from_key=prefix_bytes):
                 # Stop when the key no longer starts with the current prefix
                 if not rdb_key.startswith(prefix_bytes):
                     break # Exit the inner loop for this prefix
 
-                # Decode the key to get components
+                # Decode the key to get components (now without dataset_name)
+                # KeyCodec.decode will need to be updated to expect key format without dataset_name
                 decoded = self.key_codec.decode(rdb_key)
 
                 if not decoded:
-                    logger.warning(f"Skipping malformed key during scan starting from {prefix_bytes.hex()}: {rdb_key.hex()}")
+                    logger.warning(f"Skipping malformed key during scan in CF {dataset_name or 'default'} starting from {prefix_bytes.hex()}: {rdb_key.hex()}")
                     continue
 
-                # Assuming decode returns (dataset_name, row_key, column_name, original_timestamp_ms)
+                # Assuming decode returns (row_key, column_name, original_timestamp_ms) after codec update
                 try:
-                    _, _, current_col_name, current_ts_ms = decoded
+                    current_row_key, current_col_name, current_ts_ms = decoded
                 except ValueError:
-                     logger.warning(f"Unexpected number of decoded parts for key {rdb_key.hex()}")
+                     logger.warning(f"Unexpected number of decoded parts for key {rdb_key.hex()} in CF {dataset_name or 'default'}")
                      continue
 
+                # Double-check that the decoded row_key matches the requested row_key,
+                # although the prefix scan should handle this, it's a good sanity check.
+                if current_row_key != row_key:
+                    logger.warning(f"Skipping key with mismatched row_key '{current_row_key}' during scan for '{row_key}' in CF {dataset_name or 'default'}: {rdb_key.hex()}")
+                    continue
+
+
                 # Optimization: If we've already collected num_versions for this column,
-                # skip processing further older versions for this column.
+                # skip processing further older versions for this column within this CF.
                 # Note: This optimization works because keys for a column prefix are sorted by timestamp descending.
                 if current_col_name in results and len(results[current_col_name]) >= num_versions:
                     continue # Move to the next key from the iterator
@@ -152,7 +212,15 @@ class WideColumnDB:
                 # Keys within a column prefix are sorted reverse-chronologically by timestamp (newest first).
                 if start_ts_ms is not None and current_ts_ms < start_ts_ms:
                     # This version is too old. Since we iterate newest-to-oldest,
-                    # all subsequent versions will also be too old.
+                    # all subsequent versions will also be too old within this column prefix.
+                    # Note: This break only applies *within the current column prefix*.
+                    # The outer loop continues to the next scan_prefix (potentially a different column).
+                    # For row-level prefix scans, this break would stop scanning the entire row.
+                    # Need to be careful with this optimization depending on prefix type.
+                    # For a row-level prefix (col_names=None), breaking here is correct as it stops
+                    # processing all older versions in the row.
+                    # For column-level prefixes (col_names list), breaking here only stops for that specific column.
+                    # The current structure handles this correctly because we iterate by prefix.
                     break # Optimization: Exit inner loop for this prefix/column
                 if end_ts_ms is not None and current_ts_ms > end_ts_ms:
                     # This version is too new. Skip it and continue to the next (older) version.
@@ -175,35 +243,43 @@ class WideColumnDB:
 
     def delete_row(self, row_key, column_names=None, dataset_name=None, specific_timestamps_ms=None):
         """
-        Deletes data for a row.
-        If column_names is None, deletes all data for the row_key.
-        If column_names is provided, deletes only those columns.
-        If specific_timestamps_ms (list) is provided with a single column_name, deletes only those specific versions.
+        Deletes data for a row within a specific dataset (Column Family).
+        If column_names is None, deletes all data for the row_key in the specified dataset.
+        If column_names is provided, deletes only those columns in the specified dataset.
+        If specific_timestamps_ms (list) is provided with a single column_name, deletes only those specific versions in the specified dataset.
+        dataset_name: The name of the dataset (Column Family) to use. Defaults to 'default'.
         """
-        # Use the db instance from the manager
-        db_instance = self._db_manager.db
-        if db_instance is None:
-            raise RuntimeError("Database is not initialized. Cannot perform delete_row operation.")
+        # Get the correct CF handle
+        cf_handle = self._get_cf_handle(dataset_name)
+
         batch, count = rocksdb.WriteBatch(), 0
 
         # Case 1: Delete specific timestamps for a single column
         if column_names and isinstance(column_names, str) and specific_timestamps_ms:
-            logger.info(f'Deleting a single column {column_names} with timestamps {specific_timestamps_ms}')
+            logger.info(f'Deleting a single column {column_names} with timestamps {specific_timestamps_ms} in CF {dataset_name or "default"}')
             single_col_name = column_names
             for ts_ms in specific_timestamps_ms:
-                rdb_key = self.key_codec.encode(dataset_name, row_key, single_col_name, ts_ms)
-                batch.delete(rdb_key)
+                # Encode key *without* dataset_name
+                rdb_key = self.key_codec.encode(None, row_key, single_col_name, ts_ms) # Pass None for dataset_name
+
+                if rdb_key is None:
+                     logger.warning(f"Key encoding failed for deletion key row '{row_key}', column '{single_col_name}', timestamp {ts_ms}. Skipping deletion for this key.")
+                     continue
+
+                # Add to batch specifying the CF handle
+                batch.delete(rdb_key, column_family=cf_handle)
                 count += 1
-            if db_instance: # Check if the instance is available
+            if count > 0:
                 try:
-                    db_instance.write(batch)
+                    # Write batch to the database instance
+                    self._db_manager.db.write(batch)
                 except Exception as e:
-                    logger.error(f"Error writing batch for specific timestamp deletion for row '{row_key}', column '{single_col_name}': {e}")
+                    logger.error(f"Error writing batch for specific timestamp deletion for row '{row_key}', column '{single_col_name}' in CF '{dataset_name or 'default'}': {e}")
                     # Re-raise the exception to indicate failure
                     raise e
             return
 
-        # Case 2 & 3: Delete columns or entire row (prefix-based deletion)
+        # Case 2 & 3: Delete columns or entire row (prefix-based deletion) within a CF
         target_cols_to_scan = []
         if column_names:
             if isinstance(column_names, str): target_cols_to_scan = [column_names]
@@ -212,23 +288,37 @@ class WideColumnDB:
         scan_prefixes_for_delete = []
         if target_cols_to_scan: # Delete specific columns
             for col_name in target_cols_to_scan:
-                scan_prefixes_for_delete.append(self.key_codec.encode(dataset_name=dataset_name, row_key=row_key, column_name=col_name))
-        else: # Delete all columns for the row_key
-            scan_prefixes_for_delete.append(self.key_codec.encode(dataset_name=dataset_name, row_key=row_key))
+                # Encode prefix *without* dataset_name
+                scan_prefixes_for_delete.append(self.key_codec.encode(None, row_key, col_name)) # Pass None for dataset_name
+        else: # Delete all columns for the row_key in the specified CF
+            # Encode prefix *without* dataset_name
+            scan_prefixes_for_delete.append(self.key_codec.encode(None, row_key)) # Pass None for dataset_name
 
-        logger.info(f'Scan prefixes to delete {scan_prefixes_for_delete}')
-        # Iterate through each prefix and use from_key to seek
-        for prefix_bytes in scan_prefixes_for_delete:
-            # Use items(from_key=prefix_bytes) to seek to the start of the prefix range
-            for rdb_key, _ in db_instance.items(from_key=prefix_bytes):
+        # Filter out any potential None results from encoding (e.g., due to length prefix limits)
+        valid_scan_prefixes = [p for p in scan_prefixes_for_delete if p is not None]
+
+        if not valid_scan_prefixes:
+            logger.warning(f"No valid scan prefixes could be generated for deletion for row '{row_key}' in CF '{dataset_name or 'default'}'. No data deleted.")
+            return
+
+        logger.info(f'Scan prefixes to delete in CF {dataset_name or "default"}: {valid_scan_prefixes}')
+
+        # Iterate through each prefix on the specific CF handle and use from_key to seek
+        for prefix_bytes in valid_scan_prefixes:
+            # Use items(from_key=prefix_bytes) on the CF handle
+            for rdb_key, _ in cf_handle.items(from_key=prefix_bytes):
                 # Stop when the key no longer starts with the current prefix
                 if not rdb_key.startswith(prefix_bytes):
                     break # Exit the inner loop for this prefix
 
-                batch.delete(rdb_key)
+                # Add to batch specifying the CF handle
+                batch.delete(rdb_key, column_family=cf_handle)
                 count += 1
+
         if count > 0: # Check if batch has operations
-             db_instance.write(batch)
+             # Write batch to the database instance
+             self._db_manager.db.write(batch)
+
 
     def close(self):
         """

--- a/tests/test_key_codecs.py
+++ b/tests/test_key_codecs.py
@@ -1,83 +1,109 @@
 import unittest
 import time
 import struct
-from src import KeyCodec, LengthPrefixedKeyCodec
+from src.key_codec import KeyCodec # Import from src
+from src.length_prefixed_key_codec import LengthPrefixedKeyCodec # Import from src
+import logging
+
+# Configure basic logging for tests
+# Avoid reconfiguring if already configured by root logging in test_wide_column_db
+if not logging.getLogger().handlers:
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+logger = logging.getLogger(__name__)
+
+
+# Moved MAX_UINT64 definition here or import from codecs if they expose it publicly
+# For now, let's use the definition from KeyCodec as it's the same.
+MAX_UINT64 = KeyCodec.MAX_UINT64
+
 
 class TestKeyCodecs(unittest.TestCase):
 
     def setUp(self):
-        """Set up a KeyCodec instance for each test."""
+        """Set up KeyCodec instances for each test."""
+        # Codecs are initialized without dataset_name consideration
         self.separator_codec = KeyCodec()
         self.length_prefixed_codec = LengthPrefixedKeyCodec()
         self.test_ts_ms = int(time.time() * 1000)
-        self.inverted_test_ts_bytes = struct.pack('>Q', KeyCodec.MAX_UINT64 - self.test_ts_ms)
+        self.inverted_test_ts_bytes = struct.pack('>Q', MAX_UINT64 - self.test_ts_ms)
 
 
-    # --- Tests for Separator-Based KeyCodec ---
+    # --- Tests for Separator-Based KeyCodec (without dataset_name) ---
 
     def test_separator_encode_full_key(self):
         key_bytes = self.separator_codec.encode(
-            dataset_name="my_dataset",
             row_key="row1",
             column_name="colA",
             timestamp_ms=self.test_ts_ms
+            # dataset_name is ignored by the codec
         )
-        expected_bytes = b"my_dataset\x00row1\x00colA\x00" + self.inverted_test_ts_bytes
-        self.assertEqual(key_bytes, expected_bytes)
-
-    def test_separator_encode_full_key_no_dataset(self):
-        key_bytes = self.separator_codec.encode(
-            row_key="row1",
-            column_name="colA",
-            timestamp_ms=self.test_ts_ms
-        )
+        # Expected format: [row_key]\x00[column_name]\x00[timestamp]
         expected_bytes = b"row1\x00colA\x00" + self.inverted_test_ts_bytes
         self.assertEqual(key_bytes, expected_bytes)
 
+    def test_separator_encode_full_key_missing_mandatory_parts(self):
+         # row_key is mandatory
+         self.assertIsNone(self.separator_codec.encode(column_name="colA", timestamp_ms=self.test_ts_ms))
+         # column_name is mandatory for a full key
+         self.assertIsNone(self.separator_codec.encode(row_key="row1", timestamp_ms=self.test_ts_ms))
+
+
     def test_separator_encode_prefix_column(self):
         prefix_bytes = self.separator_codec.encode(
-            dataset_name="my_dataset",
             row_key="row1",
             column_name="colA"
+            # dataset_name is ignored
         )
-        expected_bytes = b"my_dataset\x00row1\x00colA\x00"
+        # Expected format: [row_key]\x00[column_name]\x00
+        expected_bytes = b"row1\x00colA\x00"
         self.assertEqual(prefix_bytes, expected_bytes)
 
     def test_separator_encode_prefix_row(self):
         prefix_bytes = self.separator_codec.encode(
-            dataset_name="my_dataset",
             row_key="row1"
+            # dataset_name and column_name are None
         )
-        expected_bytes = b"my_dataset\x00row1\x00"
+        # Expected format: [row_key]\x00
+        expected_bytes = b"row1\x00"
         self.assertEqual(prefix_bytes, expected_bytes)
 
-    def test_separator_decode_full_key(self):
-        encoded_key = b"my_dataset\x00row1\x00colA\x00" + self.inverted_test_ts_bytes
-        decoded = self.separator_codec.decode(encoded_key)
-        self.assertEqual(decoded, ("my_dataset", "row1", "colA", self.test_ts_ms))
 
-    def test_separator_decode_full_key_no_dataset(self):
+    def test_separator_decode_full_key(self):
+        # Encoded key without dataset_name
         encoded_key = b"row1\x00colA\x00" + self.inverted_test_ts_bytes
         decoded = self.separator_codec.decode(encoded_key)
-        self.assertEqual(decoded, (None, "row1", "colA", self.test_ts_ms))
+        # Expected decoded format: (row_key, column_name, original_timestamp_ms)
+        self.assertEqual(decoded, ("row1", "colA", self.test_ts_ms))
+
 
     def test_separator_decode_malformed(self):
-        # Missing parts
-        malformed_key = b"row1\x00colA"
-        self.assertIsNone(self.separator_codec.decode(malformed_key))
+        # Missing expected parts (should be 3 parts: row, col, ts)
+        malformed_key_too_few_parts = b"row1\x00colA"
+        self.assertIsNone(self.separator_codec.decode(malformed_key_too_few_parts))
+
+        malformed_key_too_many_parts = b"part1\x00part2\x00part3\x00part4" # 4 parts
+        self.assertIsNone(self.separator_codec.decode(malformed_key_too_many_parts))
+
 
         # Wrong timestamp size
-        malformed_key = b"row1\x00colA\x00" + b"\x00" * 7 # 7 bytes instead of 8
-        self.assertIsNone(self.separator_codec.decode(malformed_key))
+        malformed_key_wrong_ts_size = b"row1\x00colA\x00" + b"\x00" * 7 # 7 bytes instead of 8
+        self.assertIsNone(self.separator_codec.decode(malformed_key_wrong_ts_size))
 
-        # Unicode error
-        malformed_key = b"row1\x00colA\x00\xff\xff" + self.inverted_test_ts_bytes # Invalid UTF-8
-        self.assertIsNone(self.separator_codec.decode(malformed_key))
+        # Unicode error in string part
+        # Malformed UTF-8 in row_key
+        malformed_key_unicode = b"\xff\xffrow1\x00colA\x00" + self.inverted_test_ts_bytes
+        self.assertIsNone(self.separator_codec.decode(malformed_key_unicode))
+        # Malformed UTF-8 in column_name
+        malformed_key_unicode = b"row1\x00colA\xff\xff\x00" + self.inverted_test_ts_bytes
+        self.assertIsNone(self.separator_codec.decode(malformed_key_unicode))
+
 
     def test_separator_timestamp_inversion(self):
         ts1 = 1678886400000 # March 15, 2023
         ts2 = 1678886460000 # March 15, 2023 + 1 min
 
+        # Keys encoded without dataset_name
         key1 = self.separator_codec.encode(row_key="r", column_name="c", timestamp_ms=ts1)
         key2 = self.separator_codec.encode(row_key="r", column_name="c", timestamp_ms=ts2)
 
@@ -87,84 +113,85 @@ class TestKeyCodecs(unittest.TestCase):
         decoded1 = self.separator_codec.decode(key1)
         decoded2 = self.separator_codec.decode(key2)
 
+        # Timestamp is the last element in the decoded tuple
         self.assertEqual(decoded1[-1], ts1)
         self.assertEqual(decoded2[-1], ts2)
 
 
-    # --- Tests for Length-Prefixed KeyCodec ---
+    # --- Tests for Length-Prefixed KeyCodec (without dataset_name) ---
 
     def test_length_prefixed_encode_full_key(self):
         key_bytes = self.length_prefixed_codec.encode(
-            dataset_name="my_dataset",
             row_key="row1",
             column_name="colA",
             timestamp_ms=self.test_ts_ms
+            # dataset_name is ignored
         )
-        # Expected: [len_dataset][dataset_name][len_row][row_key][len_column][column_name][timestamp]
-        expected_bytes = b'\x0amy_dataset\x04row1\x04colA' + self.inverted_test_ts_bytes
+        # Expected format: [len_row][row_key][len_column][column_name][timestamp]
+        expected_bytes = b'\x04row1\x04colA' + self.inverted_test_ts_bytes
         self.assertEqual(key_bytes, expected_bytes)
 
-    def test_length_prefixed_encode_full_key_no_dataset(self):
-        key_bytes = self.length_prefixed_codec.encode(
-            dataset_name=None, # Explicitly None
-            row_key="row1",
-            column_name="colA",
-            timestamp_ms=self.test_ts_ms
-        )
-         # Expected: [len_dataset=0][len_row][row_key][len_column][column_name][timestamp]
-        expected_bytes = b'\x00\x04row1\x04colA' + self.inverted_test_ts_bytes
-        self.assertEqual(key_bytes, expected_bytes)
+    def test_length_prefixed_encode_full_key_missing_mandatory_parts(self):
+         # row_key is mandatory
+         self.assertIsNone(self.length_prefixed_codec.encode(column_name="colA", timestamp_ms=self.test_ts_ms))
+         # column_name is mandatory for a full key
+         self.assertIsNone(self.length_prefixed_codec.encode(row_key="row1", timestamp_ms=self.test_ts_ms))
+
 
     def test_length_prefixed_encode_prefix_column(self):
         prefix_bytes = self.length_prefixed_codec.encode(
-            dataset_name="my_dataset",
             row_key="row1",
             column_name="colA"
+            # dataset_name is ignored
         )
-         # Expected: [len_dataset][dataset_name][len_row][row_key][len_column][column_name]
-        expected_bytes = b'\x0amy_dataset\x04row1\x04colA'
+         # Expected format: [len_row][row_key][len_column][column_name]
+        expected_bytes = b'\x04row1\x04colA'
         self.assertEqual(prefix_bytes, expected_bytes)
 
     def test_length_prefixed_encode_prefix_row(self):
         prefix_bytes = self.length_prefixed_codec.encode(
-            dataset_name="my_dataset",
             row_key="row1"
+            # dataset_name and column_name are None
         )
-        # Expected: [len_dataset][dataset_name][len_row][row_key][len_column=0]
-        expected_bytes = b'\x0amy_dataset\x04row1\x00'
+        # Expected format: [len_row][row_key][len_column=0]
+        expected_bytes = b'\x04row1\x00' # Length prefix for column_name (0) should be included
         self.assertEqual(prefix_bytes, expected_bytes)
 
-    def test_length_prefixed_decode_full_key(self):
-        encoded_key = b'\x0amy_dataset\x04row1\x04colA' + self.inverted_test_ts_bytes
-        decoded = self.length_prefixed_codec.decode(encoded_key)
-        self.assertEqual(decoded, ("my_dataset", "row1", "colA", self.test_ts_ms))
 
-    def test_length_prefixed_decode_full_key_no_dataset(self):
-        encoded_key = b'\x00\x04row1\x04colA' + self.inverted_test_ts_bytes
+    def test_length_prefixed_decode_full_key(self):
+        # Encoded key without dataset_name
+        encoded_key = b'\x04row1\x04colA' + self.inverted_test_ts_bytes
         decoded = self.length_prefixed_codec.decode(encoded_key)
-        self.assertEqual(decoded, (None, "row1", "colA", self.test_ts_ms))
+        # Expected decoded format: (row_key, column_name, original_timestamp_ms)
+        self.assertEqual(decoded, ("row1", "colA", self.test_ts_ms))
 
     def test_length_prefixed_decode_malformed(self):
         # Not enough data for length byte
-        malformed_key = b'\x0amy_dataset\x04row1\x04colA'[:-1] # Cut off last byte
-        self.assertIsNone(self.length_prefixed_codec.decode(malformed_key))
+        malformed_key_len_byte = b'\x04row1\x04colA'[:-1] # Cut off last byte of colA len prefix
+        self.assertIsNone(self.length_prefixed_codec.decode(malformed_key_len_byte))
 
         # Not enough data for part based on length byte
-        malformed_key = b'\x0amy_dataset\x04row1\x04colA' + b'\x05' + b'abc' # Declares 5 bytes, provides 3
-        self.assertIsNone(self.length_prefixed_codec.decode(malformed_key))
+        malformed_key_part_data = b'\x04row1\x05colA' # len_column is 5, but only 4 bytes follow
+        self.assertIsNone(self.length_prefixed_codec.decode(malformed_key_part_data))
 
         # Wrong timestamp size
-        malformed_key = b'\x0amy_dataset\x04row1\x04colA' + b'\x00' * 7 # 7 bytes instead of 8
-        self.assertIsNone(self.length_prefixed_codec.decode(malformed_key))
+        malformed_key_wrong_ts_size = b'\x04row1\x04colA' + b'\x00' * 7 # 7 bytes instead of 8
+        self.assertIsNone(self.length_prefixed_codec.decode(malformed_key_wrong_ts_size))
 
          # Unicode error within a part
-        malformed_key = b'\x0amy_dataset\x04row1\x04colA' + b'\x02\xff\xff' + self.inverted_test_ts_bytes # Invalid UTF-8 in dataset part
-        self.assertIsNone(self.length_prefixed_codec.decode(b'\x0amy_datas\xff\xff\x04row1\x04colA' + self.inverted_test_ts_bytes))
+        # Malformed UTF-8 in row_key
+        malformed_key_unicode_row = b'\x04ro\xff\xff\x04colA' + self.inverted_test_ts_bytes
+        self.assertIsNone(self.length_prefixed_codec.decode(malformed_key_unicode_row))
+        # Malformed UTF-8 in column_name
+        malformed_key_unicode_col = b'\x04row1\x04col\xff\xff' + self.inverted_test_ts_bytes
+        self.assertIsNone(self.length_prefixed_codec.decode(malformed_key_unicode_col))
+
 
     def test_length_prefixed_timestamp_inversion(self):
         ts1 = 1678886400000 # March 15, 2023
         ts2 = 1678886460000 # March 15, 2023 + 1 min
 
+        # Keys encoded without dataset_name
         key1 = self.length_prefixed_codec.encode(row_key="r", column_name="c", timestamp_ms=ts1)
         key2 = self.length_prefixed_codec.encode(row_key="r", column_name="c", timestamp_ms=ts2)
 
@@ -174,28 +201,34 @@ class TestKeyCodecs(unittest.TestCase):
         decoded1 = self.length_prefixed_codec.decode(key1)
         decoded2 = self.length_prefixed_codec.decode(key2)
 
+        # Timestamp is the last element in the decoded tuple
         self.assertEqual(decoded1[-1], ts1)
         self.assertEqual(decoded2[-1], ts2)
+
 
     def test_length_prefixed_encode_long_part(self):
         # A string > 255 bytes
         long_string = "a" * 256
-        self.assertIsNone(self.length_prefixed_codec.encode(row_key=long_string, column_name="colA"))
+        # Encoding row_key should fail if it's too long
+        self.assertIsNone(self.length_prefixed_codec.encode(row_key=long_string, column_name="colA", timestamp_ms=self.test_ts_ms))
+         # Encoding column_name should fail if it's too long
+        self.assertIsNone(self.length_prefixed_codec.encode(row_key="row1", column_name=long_string, timestamp_ms=self.test_ts_ms))
+
 
     def test_length_prefixed_encode_empty_strings(self):
         key_bytes = self.length_prefixed_codec.encode(
-            dataset_name="",
             row_key="",
             column_name="",
             timestamp_ms=self.test_ts_ms
         )
-        # Expected: [len=0][len=0][len=0][timestamp]
-        expected_bytes = b'\x00\x00\x00' + self.inverted_test_ts_bytes
+        # Expected: [len=0][len=0][timestamp]
+        expected_bytes = b'\x00\x00' + self.inverted_test_ts_bytes
         self.assertEqual(key_bytes, expected_bytes)
 
         decoded = self.length_prefixed_codec.decode(key_bytes)
-        # Empty strings should decode to None by the _decode_part logic, which seems reasonable.
-        self.assertEqual(decoded, (None, None, None, self.test_ts_ms))
+        # Empty strings encoded as length 0 should decode to None by the _decode_part logic.
+        self.assertEqual(decoded, (None, None, self.test_ts_ms))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_key_codecs.py
+++ b/tests/test_key_codecs.py
@@ -154,7 +154,7 @@ class TestKeyCodecs(unittest.TestCase):
             # dataset_name and column_name are None
         )
         # Expected format: [len_row][row_key][len_column=0]
-        expected_bytes = b'\x04row1\x00' # Length prefix for column_name (0) should be included
+        expected_bytes = b'\x04row1' # Length prefix for column_name (0) should be included
         self.assertEqual(prefix_bytes, expected_bytes)
 
 

--- a/tests/test_wide_column_db.py
+++ b/tests/test_wide_column_db.py
@@ -213,8 +213,9 @@ class TestWideColumnDB(unittest.TestCase):
 
         # Get from dataset1 within a time range (inclusive)
         # Range: ts_middle to ts_latest
+        # Explicitly set num_versions high to allow time range to filter
         result = self.db.get_row(row_key, column_names=col_name, dataset_name=dataset_name,
-                                start_ts_ms=ts_middle, end_ts_ms=ts_latest)
+                                start_ts_ms=ts_middle, end_ts_ms=ts_latest, num_versions=4)
 
         self.assertIn(col_name, result)
         self.assertEqual(len(result[col_name]), 3)
@@ -224,24 +225,27 @@ class TestWideColumnDB(unittest.TestCase):
         self.assertEqual(result[col_name][2], (ts_middle, "middle"))
 
         # Get from dataset1 with only start time
+        # Explicitly set num_versions high to allow time range to filter
         result_start_only = self.db.get_row(row_key, column_names=col_name, dataset_name=dataset_name,
-                                            start_ts_ms=ts_late)
+                                            start_ts_ms=ts_late, num_versions=4)
         self.assertIn(col_name, result_start_only)
         self.assertEqual(len(result_start_only[col_name]), 2)
         self.assertEqual(result_start_only[col_name][0], (ts_latest, "latest"))
         self.assertEqual(result_start_only[col_name][1], (ts_late, "late"))
 
         # Get from dataset1 with only end time
+        # Explicitly set num_versions high to allow time range to filter
         result_end_only = self.db.get_row(row_key, column_names=col_name, dataset_name=dataset_name,
-                                          end_ts_ms=ts_middle)
+                                          end_ts_ms=ts_middle, num_versions=4)
         self.assertIn(col_name, result_end_only)
         self.assertEqual(len(result_end_only[col_name]), 2)
         self.assertEqual(result_end_only[col_name][0], (ts_middle, "middle")) # Newest first in range
         self.assertEqual(result_end_only[col_name][1], (ts_early, "early"))
 
         # Get from default CF with same time range - should only get default values
+        # Explicitly set num_versions high to allow time range to filter
         result_default_range = self.db.get_row(row_key, column_names=col_name, dataset_name=None,
-                                                start_ts_ms=ts_middle, end_ts_ms=ts_latest)
+                                                start_ts_ms=ts_middle, end_ts_ms=ts_latest, num_versions=4)
         # Default CF only had ts_latest in this range
         self.assertIn(col_name, result_default_range)
         self.assertEqual(len(result_default_range[col_name]), 1)

--- a/tests/test_wide_column_db.py
+++ b/tests/test_wide_column_db.py
@@ -1,581 +1,907 @@
 import unittest
-import time
-import shutil
+import rocksdict as rocksdb
 import os
-import sys
-
-# Ensure the 'vibecoding' directory (which contains the 'kvwc' package) is in sys.path.
-# This allows 'from kvwc import ...' to work correctly when running this test script directly.
-# Python will look for 'kvwc' inside the directories listed in sys.path.
-#
-# Project Structure relevant to this path modification:
-# vibecoding/            (This directory needs to be in sys.path)
-# ├── kvwc/              (This is the 'kvwc' package)
-# │   ├── __init__.py
-# │   └── wide_column_db.py
-# │   └── pyproject.toml (Defines 'kvwc' as the project, located in this dir)
-# └── kvwc/tests/        (The directory containing this test script)
-#     └── test_wide_column_db.py
-#
-# Path calculation:
-# __file__ is .../kvwc/tests/test_wide_column_db.py
-# SCRIPT_DIR is .../kvwc/tests/
-# KVWC_DIR (directory of the 'kvwc' package) is .../kvwc/
-# PROJECT_ROOT_DIR (directory containing the 'kvwc' package) is .../
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-KVWC_DIR = os.path.dirname(SCRIPT_DIR) # This is kvwc
-PROJECT_ROOT_DIR = os.path.dirname(KVWC_DIR) # This is /
-
-if PROJECT_ROOT_DIR not in sys.path:
-    sys.path.insert(0, PROJECT_ROOT_DIR)
-
-from src import WideColumnDB
+import shutil
+import time
+from src.wide_column_db import WideColumnDB
 from src.key_codec import KeyCodec
+from src.length_prefixed_key_codec import LengthPrefixedKeyCodec
+from src.serializer import StrSerializer, PickleSerializer, JsonSerializer, MsgPackSerializer # Import all serializers
+import logging
 
-TEST_DB_PATH_BASE = "test_db_temp_wide_column_main"
+# Configure basic logging for tests
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
 
 class TestWideColumnDB(unittest.TestCase):
-    db_path = None
-    db = None
+    TEST_DB_PATH = "test_rocksdb_cf"
+    # Define specific column families for testing
+    TEST_CFS = ["dataset1", "dataset2", "another_cf"]
 
     @classmethod
     def setUpClass(cls):
-        if os.path.exists(TEST_DB_PATH_BASE):
-            shutil.rmtree(TEST_DB_PATH_BASE)
-        os.makedirs(TEST_DB_PATH_BASE)
-
-    def setUp(self):
-        # Generate a unique DB path for each test method to ensure isolation
-        test_method_name = self.id().split('.')[-1]
-        self.db_path = os.path.join(TEST_DB_PATH_BASE, test_method_name)
-
-        # Clean up any remnants from a previous failed run for this specific test
-        if os.path.exists(self.db_path):
-            shutil.rmtree(self.db_path)
-
-        self.db = WideColumnDB(self.db_path)
-        self.current_time = int(time.time() * 1000)
-
-    def tearDown(self):
-        if self.db:
-            self.db.close() # self.db.db is set to None here
-            self.db = None # Ensure the TestWideColumnDB's own db attribute is None
-
-        if self.db_path and os.path.exists(self.db_path):
-            try:
-                shutil.rmtree(self.db_path)
-            except OSError as e:
-                # Handle cases where db might not be fully released, common on Windows
-                print(f"Warning: Could not remove {self.db_path} during teardown: {e}")
-        self.db_path = None
+        """Set up the test database directory once for all tests."""
+        if os.path.exists(cls.TEST_DB_PATH):
+            shutil.rmtree(cls.TEST_DB_PATH)
+        # Database creation is now handled by RocksDBManager within WideColumnDB
 
     @classmethod
     def tearDownClass(cls):
-        if os.path.exists(TEST_DB_PATH_BASE):
-            try:
-                shutil.rmtree(TEST_DB_PATH_BASE)
-            except OSError as e:
-                 print(f"Warning: Could not remove {TEST_DB_PATH_BASE} during class teardown: {e}")
+        """Clean up the test database directory once after all tests."""
+        if os.path.exists(cls.TEST_DB_PATH):
+            shutil.rmtree(cls.TEST_DB_PATH)
 
-    def test_put_get_single_item(self):
-        row_key = "user1"
-        col_name = "email"
-        value = "user1@example.com"
-        ts = self.current_time
+    def setUp(self):
+        """Create a new WideColumnDB instance for each test with specific CFs."""
+        # Ensure the directory is clean before each test
+        if os.path.exists(self.TEST_DB_PATH):
+            shutil.rmtree(self.TEST_DB_PATH)
+        # Initialize WideColumnDB with the test Column Families
+        self.db = WideColumnDB(self.TEST_DB_PATH, column_families=self.TEST_CFS)
+        # Use default codecs and serializers unless a test specifies otherwise
 
+    def tearDown(self):
+        """Close the database after each test."""
+        if self.db:
+            self.db.close()
+
+    def test_put_get_single_item_default_cf(self):
+        """Test putting and getting a single item in the default CF."""
+        row_key = "row1"
+        col_name = "colA"
+        value = "value1"
+        ts = int(time.time() * 1000)
+
+        # Put without dataset_name (uses default CF)
         self.db.put_row(row_key, [(col_name, value, ts)])
 
-        result = self.db.get_row(row_key, column_names=[col_name])
+        # Get without dataset_name (reads from default CF)
+        result = self.db.get_row(row_key, column_names=col_name)
+
         self.assertIn(col_name, result)
         self.assertEqual(len(result[col_name]), 1)
         self.assertEqual(result[col_name][0], (ts, value))
 
-    def test_put_get_multiple_items(self):
-        row_key = "product1"
-        items = [
-            ("name", "Laptop", self.current_time - 100),
-            ("price", "1200.00", self.current_time - 50),
-            ("category", "Electronics", self.current_time)
-        ]
-        self.db.put_row(row_key, items)
+    def test_put_get_single_item_specific_cf(self):
+        """Test putting and getting a single item in a specific CF."""
+        row_key = "row1"
+        col_name = "colA"
+        value = "value1"
+        ts = int(time.time() * 1000)
+        dataset_name = self.TEST_CFS[0] # Use 'dataset1'
 
-        result_all = self.db.get_row(row_key)
-        self.assertEqual(len(result_all), 3)
-        self.assertEqual(result_all["name"][0], (self.current_time - 100, "Laptop"))
-        self.assertEqual(result_all["price"][0], (self.current_time - 50, "1200.00"))
-        self.assertEqual(result_all["category"][0], (self.current_time, "Electronics"))
+        # Put with dataset_name
+        self.db.put_row(row_key, [(col_name, value, ts)], dataset_name=dataset_name)
 
-        result_specific_cols = self.db.get_row(row_key, column_names=["name", "category"])
-        self.assertEqual(len(result_specific_cols), 2)
-        self.assertIn("name", result_specific_cols)
-        self.assertIn("category", result_specific_cols)
-        self.assertNotIn("price", result_specific_cols)
+        # Get from the specific dataset_name
+        result = self.db.get_row(row_key, column_names=col_name, dataset_name=dataset_name)
 
-        result_single_col_str = self.db.get_row(row_key, column_names="price")
-        self.assertEqual(len(result_single_col_str), 1)
-        self.assertIn("price", result_single_col_str)
-
-    def test_put_get_no_timestamp_uses_current(self):
-        row_key = "event1"
-        col_name = "type"
-        value = "login"
-
-        time_before_put = int(time.time() * 1000)
-        self.db.put_row(row_key, [(col_name, value)]) # No timestamp provided
-        # Add a small sleep to ensure the write is visible before reading
-        time.sleep(0.1)
-        time_after_put = int(time.time() * 1000)
-
-        result = self.db.get_row(row_key, column_names=[col_name])
         self.assertIn(col_name, result)
         self.assertEqual(len(result[col_name]), 1)
+        self.assertEqual(result[col_name][0], (ts, value))
 
+        # Verify that getting from a *different* CF or default doesn't return the data
+        result_default = self.db.get_row(row_key, column_names=col_name, dataset_name=None)
+        self.assertNotIn(col_name, result_default)
+
+        result_other_cf = self.db.get_row(row_key, column_names=col_name, dataset_name=self.TEST_CFS[1])
+        self.assertNotIn(col_name, result_other_cf)
+
+
+    def test_put_get_multiple_items_same_row_diff_cols_diff_cfs(self):
+        """Test putting multiple items in the same row across different columns and CFs."""
+        row_key = "row1"
+        ts = int(time.time() * 1000)
+
+        # Put items in default CF
+        self.db.put_row(row_key, [("colA", "valA_default", ts)], dataset_name=None)
+        self.db.put_row(row_key, [("colB", "valB_default", ts)], dataset_name=None)
+
+        # Put items in dataset1 CF
+        self.db.put_row(row_key, [("colA", "valA_dataset1", ts)], dataset_name=self.TEST_CFS[0])
+        self.db.put_row(row_key, [("colC", "valC_dataset1", ts)], dataset_name=self.TEST_CFS[0])
+
+        # Get from default CF - should only get colA and colB from default
+        result_default = self.db.get_row(row_key)
+        self.assertIn("colA", result_default)
+        self.assertIn("colB", result_default)
+        self.assertNotIn("colC", result_default)
+        self.assertEqual(result_default["colA"][0], (ts, "valA_default"))
+        self.assertEqual(result_default["colB"][0], (ts, "valB_default"))
+
+
+        # Get from dataset1 CF - should only get colA and colC from dataset1
+        result_dataset1 = self.db.get_row(row_key, dataset_name=self.TEST_CFS[0])
+        self.assertIn("colA", result_dataset1)
+        self.assertIn("colC", result_dataset1)
+        self.assertNotIn("colB", result_dataset1)
+        self.assertEqual(result_dataset1["colA"][0], (ts, "valA_dataset1"))
+        self.assertEqual(result_dataset1["colC"][0], (ts, "valC_dataset1"))
+
+        # Get from another_cf - should be empty
+        result_another = self.db.get_row(row_key, dataset_name=self.TEST_CFS[2])
+        self.assertEqual(result_another, {})
+
+
+    def test_put_get_no_timestamp_uses_current_default_cf(self):
+        """Test put with no timestamp uses current time in default CF."""
+        row_key = "row_ts"
+        col_name = "col_ts"
+        value = "value_ts"
+
+        # Capture start time
+        start_ts = int(time.time() * 1000)
+        # Put without timestamp (uses current time)
+        self.db.put_row(row_key, [(col_name, value)])
+        # Capture end time
+        end_ts = int(time.time() * 1000)
+
+        result = self.db.get_row(row_key, column_names=col_name)
+
+        self.assertIn(col_name, result)
+        self.assertEqual(len(result[col_name]), 1)
         retrieved_ts, retrieved_value = result[col_name][0]
+
         self.assertEqual(retrieved_value, value)
-        self.assertTrue(time_before_put <= retrieved_ts <= time_after_put + 5, f"Timestamp {retrieved_ts} out of range ({time_before_put}, {time_after_put+5})") # Allow a small delta
+        # Check if the timestamp is within the expected range
+        self.assertTrue(start_ts <= retrieved_ts <= end_ts, f"Timestamp {retrieved_ts} not between {start_ts} and {end_ts}")
 
-    def test_get_num_versions(self):
-        row_key = "config_setting"
-        col_name = "timeout"
-        ts1 = self.current_time - 200
-        ts2 = self.current_time - 100
-        ts3 = self.current_time
+    def test_get_num_versions_specific_cf(self):
+        """Test retrieving multiple versions from a specific CF."""
+        row_key = "row_versions"
+        col_name = "col_v"
+        dataset_name = self.TEST_CFS[1] # Use 'dataset2'
 
-        self.db.put_row(row_key, [(col_name, "10s", ts1)])
-        self.db.put_row(row_key, [(col_name, "20s", ts2)])
-        self.db.put_row(row_key, [(col_name, "30s", ts3)])
+        ts1 = int(time.time() * 1000) - 10000 # Older
+        ts2 = int(time.time() * 1000) - 5000  # Newer
+        ts3 = int(time.time() * 1000)          # Newest
 
-        # Get 1 version (latest)
-        result1 = self.db.get_row(row_key, [col_name], num_versions=1)
-        self.assertEqual(len(result1[col_name]), 1)
-        self.assertEqual(result1[col_name][0], (ts3, "30s"))
+        # Put multiple versions with different timestamps in dataset2
+        self.db.put_row(row_key, [(col_name, "value1", ts1)], dataset_name=dataset_name)
+        self.db.put_row(row_key, [(col_name, "value2", ts2)], dataset_name=dataset_name)
+        self.db.put_row(row_key, [(col_name, "value3", ts3)], dataset_name=dataset_name)
 
-        # Get 2 versions
-        result2 = self.db.get_row(row_key, [col_name], num_versions=2)
-        self.assertEqual(len(result2[col_name]), 2)
-        self.assertEqual(result2[col_name][0], (ts3, "30s")) # Newest
-        self.assertEqual(result2[col_name][1], (ts2, "20s")) # Second newest
-
-        # Get all 3 versions
-        result3 = self.db.get_row(row_key, [col_name], num_versions=3)
-        self.assertEqual(len(result3[col_name]), 3)
-        self.assertEqual(result3[col_name][0], (ts3, "30s"))
-        self.assertEqual(result3[col_name][1], (ts2, "20s"))
-        self.assertEqual(result3[col_name][2], (ts1, "10s"))
-
-        # Request more versions than exist
-        result_more = self.db.get_row(row_key, [col_name], num_versions=5)
-        self.assertEqual(len(result_more[col_name]), 3) # Should return all available
-
-    def test_put_get_with_dataset(self):
-        dataset1 = "dset_alpha"
-        dataset2 = "dset_beta"
-        row_key = "shared_key"
-        col_name = "data_val"
-        ts = self.current_time
-
-        self.db.put_row(row_key, [(col_name, "alpha_value", ts)], dataset_name=dataset1)
-        self.db.put_row(row_key, [(col_name, "beta_value", ts + 1)], dataset_name=dataset2)
-        self.db.put_row(row_key, [(col_name, "no_dataset_value", ts + 2)])
-
-        # Get from dataset1
-        res_alpha = self.db.get_row(row_key, [col_name], dataset_name=dataset1)
-        self.assertEqual(res_alpha[col_name][0], (ts, "alpha_value"))
-
-        # Get from dataset2
-        res_beta = self.db.get_row(row_key, [col_name], dataset_name=dataset2)
-        self.assertEqual(res_beta[col_name][0], (ts + 1, "beta_value"))
-
-        # Get without dataset (should only get the non-dataset entry)
-        res_none = self.db.get_row(row_key, [col_name])
-        self.assertEqual(res_none[col_name][0], (ts + 2, "no_dataset_value"))
-
-        # Get ALL columns for row_key in dataset1 (should only be one column)
-        res_alpha_all_cols = self.db.get_row(row_key, dataset_name=dataset1)
-        self.assertIn(col_name, res_alpha_all_cols)
-        self.assertEqual(len(res_alpha_all_cols), 1)
-
-    def test_get_time_range(self):
-        row_key = "timeseries_data"
-        col_name = "value"
-        ts_base = self.current_time
-        timestamps = [ts_base - 300, ts_base - 200, ts_base - 100, ts_base]
-        values = ["v_oldest", "v_mid_old", "v_mid_new", "v_newest"]
-
-        for i, ts in enumerate(timestamps):
-            self.db.put_row(row_key, [(col_name, values[i], ts)])
-
-        # Range including mid_old and mid_new
-        result = self.db.get_row(row_key, [col_name],
-                                 start_ts_ms=timestamps[1], # ts_base - 200
-                                 end_ts_ms=timestamps[2],   # ts_base - 100
-                                 num_versions=10)
-        self.assertEqual(len(result[col_name]), 2)
-        self.assertIn((timestamps[2], values[2]), result[col_name]) # v_mid_new (newer)
-        self.assertIn((timestamps[1], values[1]), result[col_name]) # v_mid_old
+        # Put some data in default CF for the same row/column to ensure isolation
+        self.db.put_row(row_key, [(col_name, "value_default", ts3)], dataset_name=None)
 
 
+        # Get 2 versions from dataset2
+        result_dataset2_v2 = self.db.get_row(row_key, column_names=col_name, num_versions=2, dataset_name=dataset_name)
+        self.assertIn(col_name, result_dataset2_v2)
+        self.assertEqual(len(result_dataset2_v2[col_name]), 2)
+        # Results should be sorted by timestamp descending (newest first)
+        self.assertEqual(result_dataset2_v2[col_name][0], (ts3, "value3"))
+        self.assertEqual(result_dataset2_v2[col_name][1], (ts2, "value2"))
 
-        # Range: only newest
-        result = self.db.get_row(row_key, [col_name], start_ts_ms=timestamps[3], num_versions=10)
-        self.assertEqual(len(result[col_name]), 1)
-        self.assertEqual(result[col_name][0], (timestamps[3], values[3]))
+        # Get 3 versions from dataset2
+        result_dataset2_v3 = self.db.get_row(row_key, column_names=col_name, num_versions=3, dataset_name=dataset_name)
+        self.assertIn(col_name, result_dataset2_v3)
+        self.assertEqual(len(result_dataset2_v3[col_name]), 3)
+        self.assertEqual(result_dataset2_v3[col_name][0], (ts3, "value3"))
+        self.assertEqual(result_dataset2_v3[col_name][1], (ts2, "value2"))
+        self.assertEqual(result_dataset2_v3[col_name][2], (ts1, "value1"))
 
-        # Range: only oldest
-        result = self.db.get_row(row_key, [col_name], end_ts_ms=timestamps[0], num_versions=10)
-        self.assertEqual(len(result[col_name]), 1)
-        self.assertEqual(result[col_name][0], (timestamps[0], values[0]))
+         # Get 1 version from default CF - should only get the default value
+        result_default_v1 = self.db.get_row(row_key, column_names=col_name, num_versions=1, dataset_name=None)
+        self.assertIn(col_name, result_default_v1)
+        self.assertEqual(len(result_default_v1[col_name]), 1)
+        self.assertEqual(result_default_v1[col_name][0], (ts3, "value_default"))
 
-        # Range: between oldest and mid_old (exclusive of actual points)
-        result = self.db.get_row(row_key, [col_name],
-                                 start_ts_ms=timestamps[0] + 1,
-                                 end_ts_ms=timestamps[1] - 1,
-                                 num_versions=10)
-        self.assertNotIn(col_name, result) # Should be empty
 
-        # Range: up to mid_new (inclusive)
-        result = self.db.get_row(row_key, [col_name], end_ts_ms=timestamps[2], num_versions=10)
-        self.assertEqual(len(result[col_name]), 3) # oldest, mid_old, mid_new
-        self.assertIn((timestamps[2], values[2]), result[col_name])
-        self.assertIn((timestamps[1], values[1]), result[col_name])
-        self.assertIn((timestamps[0], values[0]), result[col_name])
+    def test_get_time_range_specific_cf(self):
+        """Test retrieving data within a time range from a specific CF."""
+        row_key = "row_time_range"
+        col_name = "col_tr"
+        dataset_name = self.TEST_CFS[0] # Use 'dataset1'
 
-        # Range: from mid_old (inclusive)
-        result = self.db.get_row(row_key, [col_name], start_ts_ms=timestamps[1], num_versions=10)
-        self.assertEqual(len(result[col_name]), 3) # mid_old, mid_new, newest
-        self.assertIn((timestamps[3], values[3]), result[col_name])
-        self.assertIn((timestamps[2], values[2]), result[col_name])
-        self.assertIn((timestamps[1], values[1]), result[col_name])
+        ts_early = int(time.time() * 1000) - 20000
+        ts_middle = int(time.time() * 1000) - 10000
+        ts_late = int(time.time() * 1000) - 5000
+        ts_latest = int(time.time() * 1000)
 
-    def test_get_non_existent(self):
-        result = self.db.get_row("non_existent_row_key")
-        self.assertEqual(len(result), 0) # Should be an empty dict
+        # Put data in dataset1
+        self.db.put_row(row_key, [(col_name, "early", ts_early)], dataset_name=dataset_name)
+        self.db.put_row(row_key, [(col_name, "middle", ts_middle)], dataset_name=dataset_name)
+        self.db.put_row(row_key, [(col_name, "late", ts_late)], dataset_name=dataset_name)
+        self.db.put_row(row_key, [(col_name, "latest", ts_latest)], dataset_name=dataset_name)
 
-        self.db.put_row("existing_row", [("colA", "valA", self.current_time)])
-        result = self.db.get_row("existing_row", ["non_existent_col"])
-        self.assertEqual(len(result), 0) # Empty dict as column not found
+        # Put data in default CF with same keys/timestamps to ensure isolation
+        self.db.put_row(row_key, [(col_name, "early_def", ts_early)], dataset_name=None)
+        self.db.put_row(row_key, [(col_name, "latest_def", ts_latest)], dataset_name=None)
 
-    def test_delete_specific_columns(self):
-        row_key = "doc1"
-        ts = self.current_time
+
+        # Get from dataset1 within a time range (inclusive)
+        # Range: ts_middle to ts_latest
+        result = self.db.get_row(row_key, column_names=col_name, dataset_name=dataset_name,
+                                start_ts_ms=ts_middle, end_ts_ms=ts_latest)
+
+        self.assertIn(col_name, result)
+        self.assertEqual(len(result[col_name]), 3)
+        # Results should be sorted descending by timestamp
+        self.assertEqual(result[col_name][0], (ts_latest, "latest"))
+        self.assertEqual(result[col_name][1], (ts_late, "late"))
+        self.assertEqual(result[col_name][2], (ts_middle, "middle"))
+
+        # Get from dataset1 with only start time
+        result_start_only = self.db.get_row(row_key, column_names=col_name, dataset_name=dataset_name,
+                                            start_ts_ms=ts_late)
+        self.assertIn(col_name, result_start_only)
+        self.assertEqual(len(result_start_only[col_name]), 2)
+        self.assertEqual(result_start_only[col_name][0], (ts_latest, "latest"))
+        self.assertEqual(result_start_only[col_name][1], (ts_late, "late"))
+
+        # Get from dataset1 with only end time
+        result_end_only = self.db.get_row(row_key, column_names=col_name, dataset_name=dataset_name,
+                                          end_ts_ms=ts_middle)
+        self.assertIn(col_name, result_end_only)
+        self.assertEqual(len(result_end_only[col_name]), 2)
+        self.assertEqual(result_end_only[col_name][0], (ts_middle, "middle")) # Newest first in range
+        self.assertEqual(result_end_only[col_name][1], (ts_early, "early"))
+
+        # Get from default CF with same time range - should only get default values
+        result_default_range = self.db.get_row(row_key, column_names=col_name, dataset_name=None,
+                                                start_ts_ms=ts_middle, end_ts_ms=ts_latest)
+        # Default CF only had ts_latest in this range
+        self.assertIn(col_name, result_default_range)
+        self.assertEqual(len(result_default_range[col_name]), 1)
+        self.assertEqual(result_default_range[col_name][0], (ts_latest, "latest_def"))
+
+
+    def test_get_non_existent_row_or_column_specific_cf(self):
+        """Test getting non-existent data from a specific CF."""
+        dataset_name = self.TEST_CFS[0] # Use 'dataset1'
+        # Put some data first in another CF to ensure DB is not entirely empty
+        self.db.put_row("existing_row", [("existing_col", "value", int(time.time()*1000))], dataset_name=self.TEST_CFS[1])
+
+        # Get non-existent row from dataset1
+        result_row = self.db.get_row("non_existent_row", dataset_name=dataset_name)
+        self.assertEqual(result_row, {})
+
+        # Get non-existent column from an existing row in dataset1
+        self.db.put_row("row_with_data", [("colA", "valA", int(time.time()*1000))], dataset_name=dataset_name)
+        result_col = self.db.get_row("row_with_data", column_names="non_existent_col", dataset_name=dataset_name)
+        self.assertEqual(result_col, {})
+
+        # Get non-existent row from default CF
+        result_row_default = self.db.get_row("non_existent_row_default", dataset_name=None)
+        self.assertEqual(result_row_default, {})
+
+
+    def test_delete_specific_columns_specific_cf(self):
+        """Test deleting specific columns in a specific CF."""
+        row_key = "row_delete_cols"
+        ts = int(time.time() * 1000)
+        dataset_name = self.TEST_CFS[0] # Use 'dataset1'
+
+        # Put data in dataset1 for row_delete_cols
         self.db.put_row(row_key, [
-            ("title", "My Doc", ts),
-            ("author", "Me", ts),
-            ("status", "draft", ts)
-        ])
+            ("colA", "valA1", ts - 1000),
+            ("colA", "valA2", ts),
+            ("colB", "valB1", ts),
+            ("colC", "valC1", ts)
+        ], dataset_name=dataset_name)
 
-        self.db.delete_row(row_key, column_names=["author", "status"])
+         # Put data in default CF for the same row/cols to ensure isolation
+        self.db.put_row(row_key, [
+            ("colA", "valA_def", ts),
+            ("colB", "valB_def", ts)
+        ], dataset_name=None)
 
-        result = self.db.get_row(row_key)
-        self.assertIn("title", result)
-        self.assertNotIn("author", result)
-        self.assertNotIn("status", result)
-        self.assertEqual(result["title"][0], (ts, "My Doc"))
+        # Verify initial state in dataset1
+        initial_data_dataset1 = self.db.get_row(row_key, dataset_name=dataset_name, num_versions=2)
+        self.assertIn("colA", initial_data_dataset1)
+        self.assertEqual(len(initial_data_dataset1["colA"]), 2)
+        self.assertIn("colB", initial_data_dataset1)
+        self.assertEqual(len(initial_data_dataset1["colB"]), 1)
+        self.assertIn("colC", initial_data_dataset1)
+        self.assertEqual(len(initial_data_dataset1["colC"]), 1)
 
-        # Delete remaining column using single string
-        self.db.delete_row(row_key, column_names="title")
-        result_final = self.db.get_row(row_key)
-        self.assertEqual(len(result_final), 0)
-
-    def test_delete_entire_row(self):
-        row_key = "session_abc"
-        ts = self.current_time
-        self.db.put_row(row_key, [("user_id", "u1", ts), ("ip", "1.2.3.4", ts)])
-        self.db.put_row(row_key, [("user_id", "u1_new", ts + 10)]) # Add another version
-
-        self.db.delete_row(row_key) # No columns specified, delete all
-        result = self.db.get_row(row_key)
-        self.assertEqual(len(result), 0)
-
-    def test_delete_with_dataset(self):
-        dataset = "logs"
-        row_key = "req123"
-        ts = self.current_time
-        self.db.put_row(row_key, [("url", "/home", ts)], dataset_name=dataset)
-        self.db.put_row(row_key, [("user_agent", "BrowserX", ts)]) # No dataset
-
-        # Delete from dataset "logs"
-        self.db.delete_row(row_key, dataset_name=dataset)
-
-        res_dataset = self.db.get_row(row_key, dataset_name=dataset)
-        self.assertEqual(len(res_dataset), 0)
-
-        res_no_dataset = self.db.get_row(row_key) # Should still have user_agent
-        self.assertIn("user_agent", res_no_dataset)
-        self.assertEqual(res_no_dataset["user_agent"][0], (ts, "BrowserX"))
-
-        # Delete the non-dataset entry as well
-        self.db.delete_row(row_key, column_names=["user_agent"])
-        res_no_dataset_after = self.db.get_row(row_key)
-        self.assertEqual(len(res_no_dataset_after), 0)
+        # Verify initial state in default CF
+        initial_data_default = self.db.get_row(row_key, dataset_name=None)
+        self.assertIn("colA", initial_data_default)
+        self.assertIn("colB", initial_data_default)
+        self.assertNotIn("colC", initial_data_default)
 
 
-    def test_delete_specific_timestamps(self):
-        row_key = "sensor_temp"
-        col_name = "reading"
-        ts1, ts2, ts3 = self.current_time - 20, self.current_time - 10, self.current_time
+        # Delete colA and colC from dataset1
+        self.db.delete_row(row_key, column_names=["colA", "colC"], dataset_name=dataset_name)
 
-        self.db.put_row(row_key, [(col_name, "20C", ts1)])
-        self.db.put_row(row_key, [(col_name, "21C", ts2)])
-        self.db.put_row(row_key, [(col_name, "22C", ts3)])
+        # Verify state in dataset1 after deletion
+        after_delete_dataset1 = self.db.get_row(row_key, dataset_name=dataset_name, num_versions=2)
+        self.assertNotIn("colA", after_delete_dataset1) # colA should be deleted
+        self.assertIn("colB", after_delete_dataset1) # colB should remain
+        self.assertNotIn("colC", after_delete_dataset1) # colC should be deleted
 
-        # Delete the middle version (ts2)
-        self.db.delete_row(row_key, column_names=col_name, specific_timestamps_ms=[ts2])
+        # Verify state in default CF (should be unaffected)
+        after_delete_default = self.db.get_row(row_key, dataset_name=None)
+        self.assertIn("colA", after_delete_default)
+        self.assertIn("colB", after_delete_default)
 
-        result = self.db.get_row(row_key, [col_name], num_versions=3)
+
+    def test_delete_entire_row_specific_cf(self):
+        """Test deleting an entire row in a specific CF."""
+        row_key = "row_delete_entire"
+        ts = int(time.time() * 1000)
+        dataset_name = self.TEST_CFS[1] # Use 'dataset2'
+
+        # Put data in dataset2 for row_delete_entire
+        self.db.put_row(row_key, [
+            ("colA", "valA1", ts),
+            ("colB", "valB1", ts)
+        ], dataset_name=dataset_name)
+
+        # Put data in default CF for the same row to ensure isolation
+        self.db.put_row(row_key, [("colA", "valA_def", ts)], dataset_name=None)
+
+        # Verify initial state in dataset2
+        initial_data_dataset2 = self.db.get_row(row_key, dataset_name=dataset_name)
+        self.assertIn("colA", initial_data_dataset2)
+        self.assertIn("colB", initial_data_dataset2)
+
+        # Verify initial state in default CF
+        initial_data_default = self.db.get_row(row_key, dataset_name=None)
+        self.assertIn("colA", initial_data_default)
+
+        # Delete the entire row in dataset2
+        self.db.delete_row(row_key, dataset_name=dataset_name)
+
+        # Verify state in dataset2 after deletion
+        after_delete_dataset2 = self.db.get_row(row_key, dataset_name=dataset_name)
+        self.assertEqual(after_delete_dataset2, {}) # Row should be empty in dataset2
+
+        # Verify state in default CF (should be unaffected)
+        after_delete_default = self.db.get_row(row_key, dataset_name=None)
+        self.assertIn("colA", after_delete_default)
+
+
+    def test_delete_with_dataset_isolation(self):
+        """Test deleting in one dataset does not affect another."""
+        row_key = "row_delete_isolated"
+        ts = int(time.time() * 1000)
+        dataset1_name = self.TEST_CFS[0]
+        dataset2_name = self.TEST_CFS[1]
+
+        # Put data in both datasets for the same row/columns
+        self.db.put_row(row_key, [("colA", "valA1", ts), ("colB", "valB1", ts)], dataset_name=dataset1_name)
+        self.db.put_row(row_key, [("colA", "valA2", ts), ("colB", "valB2", ts)], dataset_name=dataset2_name)
+
+        # Verify initial state
+        data_dataset1_before = self.db.get_row(row_key, dataset_name=dataset1_name)
+        data_dataset2_before = self.db.get_row(row_key, dataset_name=dataset2_name)
+        self.assertIn("colA", data_dataset1_before)
+        self.assertIn("colB", data_dataset1_before)
+        self.assertIn("colA", data_dataset2_before)
+        self.assertIn("colB", data_dataset2_before)
+
+        # Delete row from dataset1
+        self.db.delete_row(row_key, dataset_name=dataset1_name)
+
+        # Verify dataset1 is empty for this row
+        data_dataset1_after = self.db.get_row(row_key, dataset_name=dataset1_name)
+        self.assertEqual(data_dataset1_after, {})
+
+        # Verify dataset2 is unaffected
+        data_dataset2_after = self.db.get_row(row_key, dataset_name=dataset2_name)
+        self.assertIn("colA", data_dataset2_after)
+        self.assertIn("colB", data_dataset2_after)
+
+
+    def test_delete_specific_timestamps_specific_cf(self):
+        """Test deleting specific timestamp versions for a column in a specific CF."""
+        row_key = "row_delete_ts"
+        col_name = "col_ts_del"
+        dataset_name = self.TEST_CFS[0] # Use 'dataset1'
+
+        ts1 = int(time.time() * 1000) - 20000
+        ts2 = int(time.time() * 1000) - 10000
+        ts3 = int(time.time() * 1000) - 5000
+        ts4 = int(time.time() * 1000) # Newest
+
+        # Put multiple versions in dataset1
+        self.db.put_row(row_key, [
+            (col_name, "val1", ts1),
+            (col_name, "val2", ts2),
+            (col_name, "val3", ts3),
+            (col_name, "val4", ts4)
+        ], dataset_name=dataset_name)
+
+        # Put similar data in default CF to ensure isolation
+        self.db.put_row(row_key, [
+             (col_name, "val1_def", ts1),
+             (col_name, "val4_def", ts4)
+        ], dataset_name=None)
+
+
+        # Verify initial state in dataset1
+        initial_data_dataset1 = self.db.get_row(row_key, column_names=col_name, dataset_name=dataset_name, num_versions=4)
+        self.assertEqual(len(initial_data_dataset1.get(col_name, [])), 4)
+
+         # Verify initial state in default CF
+        initial_data_default = self.db.get_row(row_key, column_names=col_name, dataset_name=None, num_versions=2)
+        self.assertEqual(len(initial_data_default.get(col_name, [])), 2)
+
+
+        # Delete specific timestamps (ts2 and ts4) from dataset1
+        self.db.delete_row(row_key, column_names=col_name, specific_timestamps_ms=[ts2, ts4], dataset_name=dataset_name)
+
+        # Verify state in dataset1 after deletion
+        after_delete_dataset1 = self.db.get_row(row_key, column_names=col_name, dataset_name=dataset_name, num_versions=4)
+        self.assertIn(col_name, after_delete_dataset1)
+        self.assertEqual(len(after_delete_dataset1[col_name]), 2)
+        # The remaining versions should be ts3 and ts1 (newest first)
+        self.assertEqual(after_delete_dataset1[col_name][0], (ts3, "val3"))
+        self.assertEqual(after_delete_dataset1[col_name][1], (ts1, "val1"))
+
+        # Verify state in default CF (should be unaffected)
+        after_delete_default = self.db.get_row(row_key, column_names=col_name, dataset_name=None, num_versions=2)
+        self.assertEqual(len(after_delete_default.get(col_name, [])), 2)
+        self.assertEqual(after_delete_default[col_name][0], (ts4, "val4_def"))
+        self.assertEqual(after_delete_default[col_name][1], (ts1, "val1_def"))
+
+
+    def test_delete_non_existent_data_specific_cf(self):
+        """Test deleting non-existent data does not raise errors in a specific CF."""
+        row_key = "row_delete_non_existent"
+        dataset_name = self.TEST_CFS[0] # Use 'dataset1'
+
+        # Ensure the row/dataset combination is initially empty
+        initial_state = self.db.get_row(row_key, dataset_name=dataset_name)
+        self.assertEqual(initial_state, {})
+
+        # Attempt to delete non-existent column
+        try:
+            self.db.delete_row(row_key, column_names="non_existent_col", dataset_name=dataset_name)
+            # If no exception is raised, the test passes for this part
+            delete_col_success = True
+        except Exception as e:
+            logger.error(f"Deleting non-existent column raised exception: {e}")
+            delete_col_success = False
+        self.assertTrue(delete_col_success, "Deleting non-existent column should not raise an error.")
+
+        # Attempt to delete non-existent specific timestamps
+        try:
+            self.db.delete_row(row_key, column_names="some_col", specific_timestamps_ms=[123, 456], dataset_name=dataset_name)
+            delete_ts_success = True
+        except Exception as e:
+            logger.error(f"Deleting non-existent timestamps raised exception: {e}")
+            delete_ts_success = False
+        self.assertTrue(delete_ts_success, "Deleting non-existent timestamps should not raise an error.")
+
+
+        # Attempt to delete non-existent entire row
+        try:
+            self.db.delete_row(row_key, dataset_name=dataset_name)
+            delete_row_success = True
+        except Exception as e:
+            logger.error(f"Deleting non-existent row raised exception: {e}")
+            delete_row_success = False
+        self.assertTrue(delete_row_success, "Deleting non-existent row should not raise an error.")
+
+
+    def test_key_encoding_order_implicit_specific_cf(self):
+        """Test that key encoding maintains correct order within a CF."""
+        row_key = "order_row"
+        col_name = "order_col"
+        dataset_name = self.TEST_CFS[2] # Use 'another_cf'
+
+        # Put data with different timestamps in the same row/col in the specific CF
+        ts1 = 1678886400000 # March 15, 2023
+        ts2 = 1678886460000 # March 15, 2023 + 1 min
+
+        self.db.put_row(row_key, [(col_name, "val1", ts1)], dataset_name=dataset_name)
+        self.db.put_row(row_key, [(col_name, "val2", ts2)], dataset_name=dataset_name)
+
+        # Getting the row should return versions newest first due to timestamp inversion
+        result = self.db.get_row(row_key, column_names=col_name, dataset_name=dataset_name, num_versions=2)
+
+        self.assertIn(col_name, result)
         self.assertEqual(len(result[col_name]), 2)
-        self.assertEqual(result[col_name][0], (ts3, "22C")) # newest
-        self.assertEqual(result[col_name][1], (ts1, "20C")) # oldest
-        self.assertNotIn((ts2, "21C"), result[col_name])
+        self.assertEqual(result[col_name][0], (ts2, "val2")) # Newest
+        self.assertEqual(result[col_name][1], (ts1, "val1")) # Older
 
-        # Delete remaining versions
-        self.db.delete_row(row_key, column_names=col_name, specific_timestamps_ms=[ts1, ts3])
-        result_final = self.db.get_row(row_key, [col_name], num_versions=3)
-        self.assertNotIn(col_name, result_final) # Column should be gone
-
-    def test_delete_non_existent_data(self):
-        # Try deleting things that aren't there, should not error
-        self.db.delete_row("non_row_key")
-        self.db.delete_row("non_row_key", column_names=["non_col"])
-        self.db.delete_row("non_row_key", column_names="non_col", specific_timestamps_ms=[self.current_time])
-
-        row_key_exists = "real_row_for_delete"
-        self.db.put_row(row_key_exists, [("actual_col", "data", self.current_time)])
-
-        # Delete non-existent column in existing row
-        self.db.delete_row(row_key_exists, column_names=["fake_col"])
-        result = self.db.get_row(row_key_exists)
-        self.assertIn("actual_col", result) # Original data should persist
-
-        # Delete non-existent timestamp for existing column
-        self.db.delete_row(row_key_exists, column_names="actual_col", specific_timestamps_ms=[self.current_time + 1000])
-        result = self.db.get_row(row_key_exists) # Original data should persist
-        self.assertEqual(result["actual_col"][0], (self.current_time, "data"))
-
-    def test_key_encoding_order_implicit(self):
-        # This is implicitly tested by test_get_num_versions,
-        # where results are expected in reverse chronological order.
-        # If encoding (inverted timestamp) was wrong, order would be wrong.
-        row_key = "implicit_order_test"
-        col_name = "val"
-        ts_older = self.current_time - 100
-        ts_newer = self.current_time
-        self.db.put_row(row_key, [(col_name, "older", ts_older)])
-        self.db.put_row(row_key, [(col_name, "newer", ts_newer)])
-
-        result = self.db.get_row(row_key, [col_name], num_versions=2)
-        self.assertEqual(result[col_name][0], (ts_newer, "newer"))
-        self.assertEqual(result[col_name][1], (ts_older, "older"))
 
     def test_close_method(self):
-        db_path_close = os.path.join(TEST_DB_PATH_BASE, "close_test_db_instance")
-        if os.path.exists(db_path_close): shutil.rmtree(db_path_close)
+        """Test that the close method can be called multiple times."""
+        db_path = "test_db_close"
+        # Clean up previous test run
+        if os.path.exists(db_path):
+            shutil.rmtree(db_path)
+        # Initialize with a CF to ensure manager handles them on close
+        db = WideColumnDB(db_path, column_families=["cf1"])
+        db.put_row("r1", [("c1", "v1")], dataset_name="cf1") # Perform an operation in the CF
+        db.put_row("r2", [("c2", "v2")], dataset_name=None) # Perform an operation in default
+        db.close()
+        logger.info("First close successful.")
+        # Calling close again should not raise an error
+        db.close()
+        logger.info("Second close successful.")
+        # Clean up the temp directory
+        if os.path.exists(db_path):
+            shutil.rmtree(db_path)
 
-        temp_db = WideColumnDB(db_path_close)
-        temp_db.put_row("r1", [("c1", "v1", self.current_time)])
 
-        temp_db.close()
-        self.assertIsNone(temp_db._db_manager.db) # Internal RocksDB instance should be None
+    def test_empty_strings_as_keys_values_specific_cf(self):
+        """Test handling of empty strings for row/column keys and values in a specific CF."""
+        row_key = "" # Empty row key
+        col_name = "" # Empty column name
+        value = "" # Empty value
+        ts = int(time.time() * 1000)
+        dataset_name = self.TEST_CFS[0] # Use 'dataset1'
 
-        with self.assertRaises(RuntimeError):
-            temp_db.put_row("r2", [("c2", "v2", self.current_time + 1)])
+        # Put item with empty strings for row, column, and value in dataset1
+        self.db.put_row(row_key, [(col_name, value, ts)], dataset_name=dataset_name)
 
-        with self.assertRaises(RuntimeError):
-            temp_db.get_row("r2", "c2")
+        # Get the item from dataset1
+        result = self.db.get_row(row_key, column_names=col_name, dataset_name=dataset_name)
 
-        # Ensure the directory is cleaned up if not handled by instance tearDown
-        if os.path.exists(db_path_close):
-            shutil.rmtree(db_path_close)
-
-    def test_empty_strings_as_keys_values(self):
-        ts = self.current_time
-        # Empty column name
-        self.db.put_row("row_empty_col", [("", "val_for_empty_col", ts)])
-        res1 = self.db.get_row("row_empty_col", [""])
-        self.assertIn("", res1)
-        self.assertEqual(res1[""][0], (ts, "val_for_empty_col"))
-
-        # Empty value
-        self.db.put_row("row_empty_val", [("col_for_empty_val", "", ts + 1)])
-        res2 = self.db.get_row("row_empty_val", ["col_for_empty_val"])
-        self.assertIn("col_for_empty_val", res2)
-        self.assertEqual(res2["col_for_empty_val"][0], (ts + 1, ""))
-
-        # Empty row key
-        self.db.put_row("", [("col_in_empty_row", "val_in_empty_row", ts + 2)])
-        res3 = self.db.get_row("", ["col_in_empty_row"])
-        self.assertIn("col_in_empty_row", res3)
-        self.assertEqual(res3["col_in_empty_row"][0], (ts + 2, "val_in_empty_row"))
-
-    def test_get_row_on_completely_empty_db(self):
-        # Create a db instance but don't call setUp which might add data for other tests
-        empty_db_path = os.path.join(TEST_DB_PATH_BASE, "totally_empty_db")
-        if os.path.exists(empty_db_path): shutil.rmtree(empty_db_path)
-
-        empty_db_instance = WideColumnDB(empty_db_path)
-        try:
-            result = empty_db_instance.get_row("any_key_whatsoever")
-            self.assertEqual(result, {})
-        finally:
-            empty_db_instance.close()
-            if os.path.exists(empty_db_path):
-                shutil.rmtree(empty_db_path)
-
-    def test_delete_row_triggers_no_write_if_nothing_deleted(self):
-        # This test checks the `if len(list(batch.iterate())) > 0:` condition
-        # by attempting to delete data that doesn't exist.
-        # No actual write to RocksDB should occur.
-        # We can't directly check if db.write was called, but we can ensure no errors.
-        self.db.delete_row("no_such_row_for_batch_check") # Should not error
-
-        # Check DB is still usable
-        self.db.put_row("after_empty_delete", [("c","v", self.current_time)])
-        res = self.db.get_row("after_empty_delete")
-        self.assertIn("c", res)
-        self.assertEqual(res["c"][0], (self.current_time, "v"))
-
-    def test_get_row_multiple_cols_varied_versions(self):
-        row_key = "multi_col_versions"
-        ts = self.current_time
-        self.db.put_row(row_key, [("colA", "A_v1", ts - 20)])
-        self.db.put_row(row_key, [("colA", "A_v2", ts - 10)])
-        self.db.put_row(row_key, [("colA", "A_v3", ts)])
-
-        self.db.put_row(row_key, [("colB", "B_v1", ts - 5)])
-
-        self.db.put_row(row_key, [("colC", "C_v1", ts - 15)])
-        self.db.put_row(row_key, [("colC", "C_v2", ts - 3)])
-
-        # Request 2 versions for colA and colB
-        result = self.db.get_row(row_key, column_names=["colA", "colB"], num_versions=2)
-
-        self.assertIn("colA", result)
-        self.assertEqual(len(result["colA"]), 2)
-        self.assertEqual(result["colA"][0], (ts, "A_v3"))
-        self.assertEqual(result["colA"][1], (ts - 10, "A_v2"))
-
-        self.assertIn("colB", result)
-        self.assertEqual(len(result["colB"]), 1) # Only 1 version exists for colB
-        self.assertEqual(result["colB"][0], (ts - 5, "B_v1"))
-
-        self.assertNotIn("colC", result) # colC was not requested
-
-        # Request all columns, default num_versions=1
-        result_all_latest = self.db.get_row(row_key)
-        self.assertEqual(len(result_all_latest["colA"]), 1)
-        self.assertEqual(result_all_latest["colA"][0], (ts, "A_v3"))
-        self.assertEqual(len(result_all_latest["colB"]), 1)
-        self.assertEqual(result_all_latest["colB"][0], (ts - 5, "B_v1"))
-        self.assertEqual(len(result_all_latest["colC"]), 1)
-        self.assertEqual(result_all_latest["colC"][0], (ts - 3, "C_v2"))
-
-    def test_get_row_num_versions_optimization(self):
-        # Test the optimization where iteration stops after num_versions are found per column
-        row_key = "optimization_test_row"
-        col_name = "data_points"
-        ts_base = self.current_time
-
-        # Put 5 versions for the column
-        versions_to_put = []
-        for i in range(5):
-            # Put older versions first to ensure reverse-chronological retrieval test
-            ts = ts_base - (5 - 1 - i) * 10 # Timestamps: ts_base - 40, ts_base - 30, ..., ts_base
-            versions_to_put.append((col_name, f"value_{i+1}", ts))
-
-        # Ensure they are put in increasing timestamp order to match common use case
-        versions_to_put.sort(key=lambda item: item[2])
-
-        self.db.put_row(row_key, versions_to_put)
-
-        # Request only 3 versions
-        num_requested = 3
-        result = self.db.get_row(row_key, [col_name], num_versions=num_requested)
-
-        # Assert that exactly num_requested versions are returned
         self.assertIn(col_name, result)
-        self.assertEqual(len(result[col_name]), num_requested)
+        self.assertEqual(len(result[col_name]), 1)
+        retrieved_ts, retrieved_value = result[col_name][0]
 
-        # Assert that the returned versions are the latest ones
-        # The expected latest versions are the last N from the sorted list,
-        # formatted as (timestamp_ms, value) tuples.
-        expected_latest_versions = [(item[2], item[1]) for item in sorted(versions_to_put, key=lambda item: item[2], reverse=True)[:num_requested]]
-        # The result is also sorted newest first
-        retrieved_versions = result[col_name]
+        self.assertEqual(retrieved_value, value) # Value should be empty string
+        self.assertEqual(retrieved_ts, ts) # Timestamp should match
 
-        self.assertEqual(retrieved_versions, expected_latest_versions)
-
-        # Request only 1 version
-        num_requested_single = 1
-        result_single = self.db.get_row(row_key, [col_name], num_versions=num_requested_single)
-        self.assertIn(col_name, result_single)
-        self.assertEqual(len(result_single[col_name]), num_requested_single)
-        # The single requested version should be the very latest one, which is the first in our expected list
-        self.assertEqual(result_single[col_name][0], expected_latest_versions[0])
+        # Get from default CF to ensure isolation
+        result_default = self.db.get_row(row_key, column_names=col_name, dataset_name=None)
+        self.assertNotIn(col_name, result_default) # Should not be in default CF
 
 
-    def test_put_row_empty_items_list(self):
-        row_key = "row_for_empty_put"
-        self.db.put_row(row_key, []) # Put with an empty list of items
+    def test_get_row_on_completely_empty_db_specific_cf(self):
+        """Test get_row on an empty DB instance for a specific CF."""
+        # The DB instance is created in setUp, but no data is put yet.
+        # Attempt to get from a specific CF
+        result_cf = self.db.get_row("any_row", dataset_name=self.TEST_CFS[0])
+        self.assertEqual(result_cf, {})
 
-        result = self.db.get_row(row_key)
-        self.assertEqual(result, {}) # Expect no data for this row
-
-        # Ensure subsequent operations are fine
-        self.db.put_row(row_key, [("col1", "val1", self.current_time)])
-        result_after = self.db.get_row(row_key)
-        self.assertIn("col1", result_after)
-        self.assertEqual(result_after["col1"][0], (self.current_time, "val1"))
-
-    def test_malformed_keys_during_decode(self):
-        # This test is a bit more internal, trying to simulate malformed keys
-        # that _decode_key might encounter. It's hard to *perfectly* simulate without
-        # direct DB manipulation, but we can try via _encode_key.
-
-        # A key that might be too short if split by KEY_SEPARATOR
-        # Manually craft a key that would lead to insufficient parts
-        raw_key_too_short = b"rowkey" + KeyCodec.KEY_SEPARATOR + b"colname"
-        # This key is missing the timestamp part
-        self.db._db_manager.db.put(raw_key_too_short, b"value")
-
-        # When get_row scans, it should ideally skip this malformed key.
-        # We put a valid key nearby to ensure scan continues.
-        self.db.put_row("rowkey", [("colname_valid", "v", self.current_time)])
-
-        # Attempt to get data for "rowkey". If _decode_key handles errors gracefully,
-        # it should skip the malformed one and return the valid one.
-        # Note: RocksDB orders keys lexicographically. "rowkey\x00colname" comes before
-        # "rowkey\x00colname_valid\x00<timestamp>" if colname < colname_valid.
-        # If colname is "z_malformed", it might come after. Let's use a name that comes first.
-
-        # Better approach: directly test _decode_key if it were public, or trust current coverage.
-        # The current test is more of an integration check for robustness.
-
-        # The `_decode_key` returns None for malformed keys, and get_row has `if not decoded: continue`
-        # So, the main test is that it doesn't crash and valid data is still retrieved.
-        res = self.db.get_row("rowkey", ["colname_valid"])
-        self.assertIn("colname_valid", res)
-        self.assertEqual(res["colname_valid"][0], (self.current_time, "v"))
-
-        # Test with dataset name expected but key is too short
-        raw_key_dataset_too_short = b"dataset" + KeyCodec.KEY_SEPARATOR + b"row" + KeyCodec.KEY_SEPARATOR + b"col"
-        self.db._db_manager.db.put(raw_key_dataset_too_short, b"value_ds_short")
-        self.db.put_row("row", [("col_valid_ds", "val_ds", self.current_time)], dataset_name="dataset")
-
-        res_ds = self.db.get_row("row", ["col_valid_ds"], dataset_name="dataset")
-        self.assertIn("col_valid_ds", res_ds)
-        self.assertEqual(res_ds["col_valid_ds"][0], (self.current_time, "val_ds"))
-
-        # Test with key that has incorrect timestamp bytes (not 8 bytes)
-        # struct.error in _decode_key
-        invalid_ts_bytes = b"short"
-        key_bad_ts = b"row_bad_ts" + KeyCodec.KEY_SEPARATOR + b"col_bad_ts" + KeyCodec.KEY_SEPARATOR + invalid_ts_bytes
-        self.db._db_manager.db.put(key_bad_ts, b"value_bad_ts")
-        self.db.put_row("row_bad_ts", [("col_good_ts", "val_good_ts", self.current_time)])
-
-        res_bad_ts = self.db.get_row("row_bad_ts", ["col_good_ts"])
-        self.assertIn("col_good_ts", res_bad_ts)
-        self.assertEqual(res_bad_ts["col_good_ts"][0], (self.current_time, "val_good_ts"))
+        # Attempt to get from default CF
+        result_default = self.db.get_row("any_row", dataset_name=None)
+        self.assertEqual(result_default, {})
 
 
-if __name__ == '__main__':
-    unittest.main()
+    def test_delete_row_triggers_no_write_if_nothing_deleted_specific_cf(self):
+        """Test that delete_row doesn't trigger a RocksDB write if no keys match in a specific CF."""
+        row_key = "row_no_delete_write"
+        dataset_name = self.TEST_CFS[0] # Use 'dataset1'
+
+        # Ensure the row/dataset is empty
+        initial_state = self.db.get_row(row_key, dataset_name=dataset_name)
+        self.assertEqual(initial_state, {})
+
+        # RocksDB does not expose a simple way to check if a write occurred without
+        # potentially impacting performance or relying on internal logging/metrics.
+        # The best we can do here is ensure no exceptions are raised when deleting
+        # non-existent data, which we test in test_delete_non_existent_data_specific_cf.
+        # This test case is left primarily as a placeholder or reminder that a
+        # more robust check would require deeper RocksDB interaction.
+        logger.info("Note: Test `test_delete_row_triggers_no_write_if_nothing_deleted_specific_cf` primarily checks for lack of errors.")
+
+        try:
+             # Attempt to delete from an empty row in the specific CF
+            self.db.delete_row(row_key, dataset_name=dataset_name)
+            delete_success = True
+        except Exception as e:
+            logger.error(f"Deleting from empty row raised exception: {e}")
+            delete_success = False
+        self.assertTrue(delete_success, "Deleting from an empty row should not raise an error.")
+
+
+    def test_get_row_multiple_cols_varied_versions_specific_cf(self):
+        """Test getting multiple columns with varied numbers of versions from a specific CF."""
+        row_key = "row_multi_col_versions"
+        dataset_name = self.TEST_CFS[1] # Use 'dataset2'
+
+        ts1 = int(time.time() * 1000) - 30000
+        ts2 = int(time.time() * 1000) - 20000
+        ts3 = int(time.time() * 1000) - 10000
+        ts4 = int(time.time() * 1000)
+
+        # Put data in dataset2
+        # colA: 2 versions
+        self.db.put_row(row_key, [("colA", "valA_old", ts1), ("colA", "valA_new", ts3)], dataset_name=dataset_name)
+        # colB: 3 versions
+        self.db.put_row(row_key, [("colB", "valB_v1", ts1), ("colB", "valB_v2", ts2), ("colB", "valB_v3", ts4)], dataset_name=dataset_name)
+        # colC: 1 version
+        self.db.put_row(row_key, [("colC", "valC_only", ts2)], dataset_name=dataset_name)
+
+        # Put similar data in default CF to ensure isolation
+        self.db.put_row(row_key, [("colA", "valA_def", ts4), ("colB", "valB_def", ts4)], dataset_name=None)
+
+
+        # Get row from dataset2 with num_versions=1 (default)
+        result_v1 = self.db.get_row(row_key, dataset_name=dataset_name)
+        self.assertIn("colA", result_v1)
+        self.assertEqual(len(result_v1["colA"]), 1)
+        self.assertEqual(result_v1["colA"][0], (ts3, "valA_new")) # Newest version of colA
+
+        self.assertIn("colB", result_v1)
+        self.assertEqual(len(result_v1["colB"]), 1)
+        self.assertEqual(result_v1["colB"][0], (ts4, "valB_v3")) # Newest version of colB
+
+        self.assertIn("colC", result_v1)
+        self.assertEqual(len(result_v1["colC"]), 1)
+        self.assertEqual(result_v1["colC"][0], (ts2, "valC_only")) # Newest version of colC
+
+        # Get row from dataset2 with num_versions=3
+        result_v3 = self.db.get_row(row_key, dataset_name=dataset_name, num_versions=3)
+        self.assertIn("colA", result_v3)
+        # colA only has 2 versions, so we should get 2, not 3
+        self.assertEqual(len(result_v3["colA"]), 2)
+        self.assertEqual(result_v3["colA"][0], (ts3, "valA_new"))
+        self.assertEqual(result_v3["colA"][1], (ts1, "valA_old"))
+
+        self.assertIn("colB", result_v3)
+        self.assertEqual(len(result_v3["colB"]), 3)
+        self.assertEqual(result_v3["colB"][0], (ts4, "valB_v3"))
+        self.assertEqual(result_v3["colB"][1], (ts2, "valB_v2"))
+        self.assertEqual(result_v3["colB"][2], (ts1, "valB_v1"))
+
+        self.assertIn("colC", result_v3)
+        # colC only has 1 version, so we should get 1, not 3
+        self.assertEqual(len(result_v3["colC"]), 1)
+        self.assertEqual(result_v3["colC"][0], (ts2, "valC_only"))
+
+        # Get row from default CF - should only get default values
+        result_default = self.db.get_row(row_key, dataset_name=None, num_versions=3)
+        self.assertIn("colA", result_default)
+        self.assertEqual(len(result_default["colA"]), 1)
+        self.assertEqual(result_default["colA"][0], (ts4, "valA_def"))
+        self.assertIn("colB", result_default)
+        self.assertEqual(len(result_default["colB"]), 1)
+        self.assertEqual(result_default["colB"][0], (ts4, "valB_def"))
+        self.assertNotIn("colC", result_default)
+
+
+    def test_get_row_num_versions_optimization_specific_cf(self):
+        """Test that get_row correctly stops scanning after reaching num_versions per column in a specific CF."""
+        row_key = "row_v_opt"
+        col_name1 = "col_opt1"
+        col_name2 = "col_opt2"
+        dataset_name = self.TEST_CFS[0] # Use 'dataset1'
+
+        # Put many versions for two columns in dataset1
+        num_versions_to_put = 10
+        timestamps1 = [int(time.time() * 1000) - i * 1000 for i in range(num_versions_to_put)]
+        timestamps2 = [int(time.time() * 1000) - i * 500 for i in range(num_versions_to_put)] # Different timestamps
+
+        items1 = [(col_name1, f"val1_{ts}", ts) for ts in timestamps1]
+        items2 = [(col_name2, f"val2_{ts}", ts) for ts in timestamps2]
+
+        self.db.put_row(row_key, items1, dataset_name=dataset_name)
+        self.db.put_row(row_key, items2, dataset_name=dataset_name)
+
+        # Put some data in default CF to ensure isolation
+        self.db.put_row(row_key, [(col_name1, "val_def", int(time.time()*1000))], dataset_name=None)
+
+
+        # Get 3 versions for both columns from dataset1
+        num_versions_to_get = 3
+        result = self.db.get_row(row_key, column_names=[col_name1, col_name2],
+                                 num_versions=num_versions_to_get, dataset_name=dataset_name)
+
+        self.assertIn(col_name1, result)
+        self.assertEqual(len(result[col_name1]), num_versions_to_get)
+        # Verify the timestamps of the retrieved versions are the newest ones
+        retrieved_ts1 = [ts for ts, _ in result[col_name1]]
+        expected_ts1 = sorted(timestamps1, reverse=True)[:num_versions_to_get]
+        self.assertEqual(retrieved_ts1, expected_ts1)
+
+        self.assertIn(col_name2, result)
+        self.assertEqual(len(result[col_name2]), num_versions_to_get)
+        # Verify the timestamps of the retrieved versions are the newest ones
+        retrieved_ts2 = [ts for ts, _ in result[col_name2]]
+        expected_ts2 = sorted(timestamps2, reverse=True)[:num_versions_to_get]
+        self.assertEqual(retrieved_ts2, expected_ts2)
+
+
+        # Get 1 version from default CF - should only get the default value
+        result_default = self.db.get_row(row_key, column_names=col_name1, dataset_name=None, num_versions=1)
+        self.assertIn(col_name1, result_default)
+        self.assertEqual(len(result_default[col_name1]), 1)
+        self.assertEqual(result_default[col_name1][0][1], "val_def") # Check value
+
+
+    def test_put_row_empty_items_list_specific_cf(self):
+        """Test calling put_row with an empty items list in a specific CF."""
+        row_key = "row_empty_put"
+        dataset_name = self.TEST_CFS[1] # Use 'dataset2'
+
+        # Verify row is empty initially
+        initial_state = self.db.get_row(row_key, dataset_name=dataset_name)
+        self.assertEqual(initial_state, {})
+
+        # Call put_row with empty list
+        try:
+            self.db.put_row(row_key, [], dataset_name=dataset_name)
+            put_success = True
+        except Exception as e:
+            logger.error(f"put_row with empty list raised exception: {e}")
+            put_success = False
+        self.assertTrue(put_success, "put_row with an empty items list should not raise an error.")
+
+        # Verify row is still empty
+        after_put_state = self.db.get_row(row_key, dataset_name=dataset_name)
+        self.assertEqual(after_put_state, {})
+
+
+    def test_malformed_keys_during_decode_specific_cf(self):
+        """Test that malformed keys encountered during iteration are skipped in a specific CF."""
+        row_key = "row_malformed_test"
+        col_name = "col_malformed"
+        dataset_name = self.TEST_CFS[0] # Use 'dataset1'
+        ts = int(time.time() * 1000)
+
+        # Put one valid key in dataset1
+        valid_key = self.db.key_codec.encode(row_key=row_key, column_name=col_name, timestamp_ms=ts)
+        valid_value = self.db.serializer.serialize("valid_value")
+
+        # Get the CF handle
+        cf_handle = self.db._get_cf_handle(dataset_name)
+
+        # Manually put a malformed key into the specific CF using the underlying rocksdict handle
+        # This bypasses the WideColumnDB's put_row which would use the codec.
+        # We need to create a key that the codec will *fail* to decode later.
+        # Example malformed key for SeparatorCodec (missing a separator/part): b"row_malformed_test\x00col_malformed"
+        # Example malformed key for LengthPrefixedKeyCodec (wrong length prefix): b'\x04row_malformed_test\x05col_malformed' + struct.pack('>Q', KeyCodec.MAX_UINT64 - ts)
+
+        codec_type = type(self.db.key_codec)
+
+        if codec_type == KeyCodec:
+             # Malformed key for SeparatorCodec: missing timestamp part
+            malformed_key = b"row_malformed_test\x00col_malformed\x00"[:-1] # Cut off part of the timestamp
+            logger.info(f"Testing malformed key for SeparatorCodec: {malformed_key.hex()}")
+            # Check that our codec actually considers this malformed
+            self.assertIsNone(self.db.key_codec.decode(malformed_key), "Codec should fail to decode this malformed key.")
+
+        elif codec_type == LengthPrefixedKeyCodec:
+             # Malformed key for LengthPrefixedKeyCodec: not enough data for part
+            malformed_key = b'\x04' + b'row_malformed_test'.encode('utf-8') + b'\x05' + b'col_malformed'.encode('utf-8')[:3] # Declares 5 bytes for col, but only provides 3
+            malformed_key += struct.pack('>Q', LengthPrefixedKeyCodec.MAX_UINT64 - ts) # Add a valid timestamp at the end using correct codec's MAX_UINT64
+            logger.info(f"Testing malformed key for LengthPrefixedKeyCodec: {malformed_key.hex()}")
+            # Check that our codec actually considers this malformed
+            self.assertIsNone(self.db.key_codec.decode(malformed_key), "Codec should fail to decode this malformed key.")
+        else:
+            self.fail(f"Unknown codec type: {codec_type.__name__}")
+            return # Stop the test if codec is unknown
+
+
+        # Use a batch to put both the valid and malformed keys atomically
+        batch = rocksdb.WriteBatch()
+        if valid_key is not None and valid_value is not None:
+            batch.put(valid_key, valid_value, column_family=cf_handle)
+        batch.put(malformed_key, b"malformed_value", column_family=cf_handle) # Put the malformed key
+
+
+        # Write the batch
+        self.db._db_manager.db.write(batch)
+
+        # Now, attempt to get the row. The iterator should encounter the malformed key,
+        # the decode method should return None, and WideColumnDB should skip it.
+        # We should only retrieve the valid key.
+        result = self.db.get_row(row_key, dataset_name=dataset_name, num_versions=2) # Requesting 2 versions to be sure iterator continues past malformed key
+
+        # Verify that only the valid key's data was returned
+        self.assertIn(col_name, result)
+        self.assertEqual(len(result[col_name]), 1)
+        retrieved_ts, retrieved_value = result[col_name][0]
+        self.assertEqual(retrieved_value, "valid_value")
+        self.assertEqual(retrieved_ts, ts)
+
+        # Verify that the malformed key did NOT prevent the valid key from being read
+        # This is implicitly tested by the assertion above.
+
+
+    def test_different_serializers_specific_cf(self):
+        """Test different serializers with put/get in a specific CF."""
+        db_path = "test_db_serializers_cf"
+        dataset_name = "serializer_cf"
+        # Clean up previous test run
+        if os.path.exists(db_path):
+            shutil.rmtree(db_path)
+
+        # Test StrSerializer (already implicitly tested, but explicitly call it out)
+        db_str = WideColumnDB(db_path, serializer=StrSerializer(), column_families=[dataset_name])
+        db_str.put_row("row_str", [("col_str", "simple string")], dataset_name=dataset_name)
+        result_str = db_str.get_row("row_str", dataset_name=dataset_name)
+        self.assertEqual(result_str.get("col_str", [])[0][1], "simple string")
+        db_str.close()
+
+
+        # Test PickleSerializer
+        db_pickle = WideColumnDB(db_path, serializer=PickleSerializer(), column_families=[dataset_name])
+        data_pickle = {"key": "value", "number": 123, "list": [1, 2, 3]}
+        db_pickle.put_row("row_pickle", [("col_pickle", data_pickle)], dataset_name=dataset_name)
+        result_pickle = db_pickle.get_row("row_pickle", dataset_name=dataset_name)
+        self.assertEqual(result_pickle.get("col_pickle", [])[0][1], data_pickle)
+        db_pickle.close()
+
+        # Test JsonSerializer
+        db_json = WideColumnDB(db_path, serializer=JsonSerializer(), column_families=[dataset_name])
+        data_json = {"key": "value", "number": 123, "list": [1, 2, 3]} # JSON friendly data
+        db_json.put_row("row_json", [("col_json", data_json)], dataset_name=dataset_name)
+        result_json = db_json.get_row("row_json", dataset_name=dataset_name)
+        self.assertEqual(result_json.get("col_json", [])[0][1], data_json)
+        db_json.close()
+
+
+        # Test MsgPackSerializer
+        db_msgpack = WideColumnDB(db_path, serializer=MsgPackSerializer(), column_families=[dataset_name])
+        data_msgpack = {"key": b"binary_value", "number": 123, "list": [1, 2, 3]} # MsgPack handles bytes
+        db_msgpack.put_row("row_msgpack", [("col_msgpack", data_msgpack)], dataset_name=dataset_name)
+        result_msgpack = db_msgpack.get_row("row_msgpack", dataset_name=dataset_name)
+        # Note: msgpack unpackb with raw=False decodes binary to str, adjust expected if necessary
+        # Assuming raw=False gives str where possible:
+        expected_msgpack_data = {"key": "binary_value", "number": 123, "list": [1, 2, 3]}
+        self.assertEqual(result_msgpack.get("col_msgpack", [])[0][1], expected_msgpack_data)
+        db_msgpack.close()
+
+
+        # Clean up the temp directory
+        if os.path.exists(db_path):
+            shutil.rmtree(db_path)
+
+
+    # Add a test for initializing WideColumnDB without specifying column_families (should use default)
+    def test_init_without_column_families_uses_default(self):
+        db_path = "test_db_no_cfs"
+        # Clean up previous test run
+        if os.path.exists(db_path):
+            shutil.rmtree(db_path)
+
+        # Initialize WideColumnDB without specifying column_families
+        db = WideColumnDB(db_path)
+
+        # Put data without dataset_name (should go to default CF)
+        db.put_row("row1", [("colA", "val1")])
+
+        # Get data without dataset_name (should read from default CF)
+        result = db.get_row("row1")
+        self.assertIn("colA", result)
+        self.assertEqual(result.get("colA", [])[0][1], "val1")
+
+        # Attempting to access a non-existent CF should raise an error
+        with self.assertRaises(ValueError):
+            db.put_row("row2", [("colB", "val2")], dataset_name="non_existent_cf")
+
+        db.close()
+
+        # Clean up
+        if os.path.exists(db_path):
+            shutil.rmtree(db_path)
+
+
+    # Add a test for providing 'default' in the column_families list explicitly
+    def test_init_with_default_in_column_families(self):
+        db_path = "test_db_explicit_default"
+        cfs_list = ["default", "my_cf"] # Explicitly include 'default'
+        # Clean up previous test run
+        if os.path.exists(db_path):
+            shutil.rmtree(db_path)
+
+        # Initialize WideColumnDB with 'default' explicitly listed
+        db = WideColumnDB(db_path, column_families=cfs_list)
+
+        # Put data without dataset_name (should go to default CF)
+        db.put_row("row1", [("colA", "val1")])
+        # Put data in the explicitly listed custom CF
+        db.put_row("row1", [("colB", "valB")], dataset_name="my_cf")
+
+
+        # Get data from default CF
+        result_default = db.get_row("row1")
+        self.assertIn("colA", result_default)
+        self.assertNotIn("colB", result_default)
+        self.assertEqual(result_default.get("colA", [])[0][1], "val1")
+
+         # Get data from custom CF
+        result_custom = db.get_row("row1", dataset_name="my_cf")
+        self.assertIn("colB", result_custom)
+        self.assertNotIn("colA", result_custom)
+        self.assertEqual(result_custom.get("colB", [])[0][1], "valB")
+
+
+        db.close()
+
+        # Clean up
+        if os.path.exists(db_path):
+            shutil.rmtree(db_path)


### PR DESCRIPTION
The code comments mention exploring Column Families (CFs) but does not implement them. Column Families in RocksDB are a crucial feature for isolating data that has different characteristics, access patterns, or requires different tuning parameters (like compression, caching, etc.). In a wide-column store, CFs could be used to:
    *   Separate different "datasets" entirely.
    *   Separate different types of data (e.g., metadata in one CF, large binary blobs in another).
    *   Isolate "hot" data from "cold" archival data.
For instance, using CFs would simplify key encoding (you wouldn't need the `dataset_name` in the key prefix if each dataset is its own CF) and improve performance and manageability.